### PR TITLE
fix: use production URL in email links instead of localhost fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,18 @@ Copy `.env.example` to `.env` and provide:
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` - OAuth App credentials
 - `GITHUB_TOKEN` - Personal access token with `read:user` and `public_repo` scopes
 - `NEXTAUTH_SECRET` - Generate with `openssl rand -base64 32`
-- `NEXTAUTH_URL` - http://localhost:3000
+- `NEXTAUTH_URL` - http://localhost:3000 (for development) or your production URL (e.g., https://yourdomain.com)
 
 **OpenAI (optional - for AI image generation):**
 - `OPENAI_API_KEY` - OpenAI API key
+
+**Email Notifications (required for access request emails):**
+- `RESEND_API_KEY` - Resend API key for sending emails
+- `RESEND_FROM_DOMAIN` - Domain for sending emails (e.g., yourdomain.com)
+- `ADMIN_EMAIL` - Email address to receive access request notifications
+
+**Redis (required for access control):**
+- `REDIS_URL` - Redis connection URL (e.g., redis://localhost:6379)
 
 ## Key Features
 

--- a/README_STORE.md
+++ b/README_STORE.md
@@ -49,7 +49,7 @@ Copy `.env.example` to `.env` and provide:
 - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` - OAuth App credentials
 - `GITHUB_TOKEN` - Personal access token with `read:user` and `public_repo` scopes
 - `NEXTAUTH_SECRET` - Generate with `openssl rand -base64 32`
-- `NEXTAUTH_URL` - http://localhost:3000
+- `NEXTAUTH_URL` - http://localhost:3000 (for development) or your production URL (e.g., https://yourdomain.com)
 
 **OpenAI (optional - for AI image generation):**
 - `OPENAI_API_KEY` - OpenAI API key

--- a/docs/store/STORE_MANAGEMENT.md
+++ b/docs/store/STORE_MANAGEMENT.md
@@ -65,7 +65,7 @@ GITHUB_CLIENT_ID=xxxxx
 GITHUB_CLIENT_SECRET=xxxxx
 GITHUB_TOKEN=ghp_xxxxx
 NEXTAUTH_SECRET=xxxxx
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://localhost:3000  # Use production URL (e.g., https://yourdomain.com) when deployed
 ```
 
 ### 2. API Tokens

--- a/src/app/api/request-access/route.ts
+++ b/src/app/api/request-access/route.ts
@@ -75,7 +75,9 @@ export async function POST(request: NextRequest) {
     const approveToken = AccessRequestsService.generateActionToken(accessRequest.id, 'approve');
     const denyToken = AccessRequestsService.generateActionToken(accessRequest.id, 'deny');
 
-    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    // Get base URL from request or environment variable
+    const requestUrl = new URL(request.url);
+    const baseUrl = process.env.NEXTAUTH_URL || `${requestUrl.protocol}//${requestUrl.host}`;
     const approveUrl = `${baseUrl}/api/admin/request-action?token=${approveToken}`;
     const denyUrl = `${baseUrl}/api/admin/request-action?token=${denyToken}`;
     const reviewUrl = `${baseUrl}/admin/requests?id=${accessRequest.id}`;

--- a/src/lib/admin/access-requests-service.ts
+++ b/src/lib/admin/access-requests-service.ts
@@ -195,7 +195,12 @@ export class AccessRequestsService {
       }
 
       const fromDomain = process.env.RESEND_FROM_DOMAIN || 'yourdomain.com';
-      const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+      const baseUrl = process.env.NEXTAUTH_URL;
+
+      if (!baseUrl) {
+        console.error('❌ NEXTAUTH_URL not configured - email will not include links');
+        // Still send email, but without the link
+      }
 
       console.log(`   From: noreply@${fromDomain}`);
       console.log(`   To: ${email}`);
@@ -212,9 +217,9 @@ export class AccessRequestsService {
                 <h1 style="color: #10b981; font-size: 32px;">🎉 Welcome!</h1>
                 <p style="font-size: 18px; color: #fff;">Your access request has been approved.</p>
                 <p style="color: #aaa; margin: 20px 0;">You can now sign in and access the React Foundation.</p>
-                <a href="${baseUrl}" style="display: inline-block; margin-top: 20px; padding: 14px 32px; background: #06b6d4; color: #000; text-decoration: none; border-radius: 8px; font-weight: bold;">
+                ${baseUrl ? `<a href="${baseUrl}" style="display: inline-block; margin-top: 20px; padding: 14px 32px; background: #06b6d4; color: #000; text-decoration: none; border-radius: 8px; font-weight: bold;">
                   Sign In Now
-                </a>
+                </a>` : '<p style="color: #666; margin-top: 20px;">Please visit the React Foundation to sign in.</p>'}
               </div>
             </body>
           </html>


### PR DESCRIPTION
Fixes #8

### Summary
This PR fixes the issue where email links were using localhost in production. The problem was caused by hardcoded fallback values that defaulted to `http://localhost:3000` when the `NEXTAUTH_URL` environment variable wasn't properly set.

### Changes
- Updated request-access API route to use request origin dynamically when NEXTAUTH_URL is not set
- Removed localhost fallback in access-requests-service.ts
- Added proper error handling for missing NEXTAUTH_URL
- Updated documentation to clarify NEXTAUTH_URL must be set to production URL
- Added missing environment variable documentation for email notifications

🤖 Generated with [Claude Code](https://claude.ai/code)