### PR TITLE
Persist community submissions to Redis, add admin review UI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -91,5 +91,9 @@
     ],
     "deny": [],
     "ask": []
-  }
+  },
+  "enabledMcpjsonServers": [
+    "redwoodjs"
+  ],
+  "enableAllProjectMcpServers": true
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -91,9 +91,5 @@
     ],
     "deny": [],
     "ask": []
-  },
-  "enabledMcpjsonServers": [
-    "redwoodjs"
-  ],
-  "enableAllProjectMcpServers": true
+  }
 }

--- a/scripts/fix-coordinates.ts
+++ b/scripts/fix-coordinates.ts
@@ -42,7 +42,7 @@ const COORDS: Record<string, { lat: number; lng: number; region?: string }> = {
 // Fix coordinates
 let fixed = 0;
 const updated = REACT_COMMUNITIES.map(comm => {
-  if (comm.coordinates.lat === 0 && comm.coordinates.lng === 0) {
+  if (!comm.coordinates || (comm.coordinates.lat === 0 && comm.coordinates.lng === 0)) {
     const coords = COORDS[comm.city];
     if (coords) {
       fixed++;

--- a/scripts/merge-all-communities.ts
+++ b/scripts/merge-all-communities.ts
@@ -100,7 +100,7 @@ async function main() {
     const key = normalizeName(comm.name);
 
     // Fix coordinates if missing
-    if (comm.coordinates.lat === 0 || comm.coordinates.lng === 0) {
+    if (!comm.coordinates || comm.coordinates.lat === 0 || comm.coordinates.lng === 0) {
       const cityCoords = CITY_COORDINATES[comm.city] || CITY_COORDINATES[`${comm.city}, ${comm.country}`];
       if (cityCoords) {
         comm.coordinates = { lat: cityCoords.lat, lng: cityCoords.lng };

--- a/src/app/admin/data/communities/page.tsx
+++ b/src/app/admin/data/communities/page.tsx
@@ -5,9 +5,11 @@
 
 import { getRedisClient } from '@/lib/redis';
 import { getCommunities, migrateFromOldFormat } from '@/lib/redis-communities';
+import { getSubmissions } from '@/lib/redis-community-submissions';
 import { RFDS } from '@/components/rfds';
 import { MigrationButton } from './migration-button';
 import { CommunitiesTable } from '@/components/admin/CommunitiesTable';
+import { PendingSubmissionsTable } from '@/components/admin/PendingSubmissionsTable';
 
 export const dynamic = 'force-dynamic';
 
@@ -40,15 +42,19 @@ async function getCommunitiesData() {
     const countries = new Set(communities.map(c => c.country)).size;
     const totalMembers = communities.reduce((sum, c) => sum + (c.member_count || 0), 0);
 
+    const submissions = await getSubmissions();
+    const pendingSubmissions = submissions.filter(s => s.verification_status === 'pending');
+
     return {
       communityKeys: communityKeys.length,
       totalCommunities: communities.length,
       activeCommunities,
       countries,
       totalMembers,
-      communities, // Include for display
+      communities,
       storageFormat,
       needsMigration: oldFormatExists && !indexExists,
+      pendingSubmissions,
     };
   } catch (error) {
     console.error('Error fetching communities data:', error);
@@ -114,6 +120,16 @@ export default async function CommunitiesPage() {
         </div>
       </div>
       
+      {/* Pending Submissions */}
+      {data.pendingSubmissions.length > 0 && (
+        <div className="bg-card border border-warning/50 rounded-xl p-6">
+          <h3 className="text-lg font-bold text-foreground mb-4">
+            Pending Submissions ({data.pendingSubmissions.length})
+          </h3>
+          <PendingSubmissionsTable submissions={data.pendingSubmissions} />
+        </div>
+      )}
+
       {/* Communities Table */}
       {data.communities && data.communities.length > 0 && (
         <div className="bg-card border border-border rounded-xl p-6">

--- a/src/app/admin/data/communities/page.tsx
+++ b/src/app/admin/data/communities/page.tsx
@@ -42,8 +42,13 @@ async function getCommunitiesData() {
     const countries = new Set(communities.map(c => c.country)).size;
     const totalMembers = communities.reduce((sum, c) => sum + (c.member_count || 0), 0);
 
-    const submissions = await getSubmissions();
-    const pendingSubmissions = submissions.filter(s => s.verification_status === 'pending');
+    let pendingSubmissions: import('@/types/community-submission').CommunitySubmission[] = [];
+    try {
+      const submissions = await getSubmissions();
+      pendingSubmissions = submissions.filter(s => s.verification_status === 'pending');
+    } catch (error) {
+      console.error('Failed to fetch submissions:', error);
+    }
 
     return {
       communityKeys: communityKeys.length,

--- a/src/app/admin/data/communities/page.tsx
+++ b/src/app/admin/data/communities/page.tsx
@@ -6,6 +6,7 @@
 import { getRedisClient } from '@/lib/redis';
 import { getCommunities, migrateFromOldFormat } from '@/lib/redis-communities';
 import { getSubmissions } from '@/lib/redis-community-submissions';
+import type { CommunitySubmission } from '@/types/community-submission';
 import { RFDS } from '@/components/rfds';
 import { MigrationButton } from './migration-button';
 import { CommunitiesTable } from '@/components/admin/CommunitiesTable';
@@ -42,7 +43,7 @@ async function getCommunitiesData() {
     const countries = new Set(communities.map(c => c.country)).size;
     const totalMembers = communities.reduce((sum, c) => sum + (c.member_count || 0), 0);
 
-    let pendingSubmissions: import('@/types/community-submission').CommunitySubmission[] = [];
+    let pendingSubmissions: CommunitySubmission[] = [];
     try {
       const submissions = await getSubmissions();
       pendingSubmissions = submissions.filter(s => s.verification_status === 'pending');

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -13,10 +13,12 @@ import { getSubmissionById, approveSubmissionAtomic } from '@/lib/redis-communit
 import type { Community } from '@/types/community';
 
 function slugify(name: string): string {
-  return name
+  const slug = name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
+  if (!slug) throw new Error(`Could not generate slug from name: "${name}"`);
+  return slug;
 }
 
 export async function POST(request: NextRequest) {
@@ -81,7 +83,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true, communityId });
   } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to approve';
+    const status = message.includes('Concurrent') || message.includes('already processed') ? 409 : 500;
     console.error('Error approving submission:', error);
-    return NextResponse.json({ error: 'Failed to approve' }, { status: 500 });
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
       country: submission.country,
       region: submission.region,
       timezone: submission.timezone ?? 'UTC',
-      coordinates: submission.coordinates ?? { lat: 0, lng: 0 },
+      coordinates: submission.coordinates,
       organizers: [
         {
           id: `org-${crypto.randomUUID()}`,

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -9,8 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { UserManagementService } from '@/lib/admin/user-management-service';
-import { getSubmissionById } from '@/lib/redis-community-submissions';
-import { approveSubmissionAtomic } from '@/lib/redis-community-submissions';
+import { getSubmissionById, approveSubmissionAtomic } from '@/lib/redis-community-submissions';
 import type { Community } from '@/types/community';
 
 function slugify(name: string): string {
@@ -71,7 +70,7 @@ export async function POST(request: NextRequest) {
       primary_language: 'English',
       status: 'new',
       invite_only: false,
-      verified: false,
+      verified: true,
       verification_status: 'verified',
       cois_tier: 'none',
       created_at: now,

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -9,8 +9,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { UserManagementService } from '@/lib/admin/user-management-service';
-import { getSubmissionById, updateSubmission, deleteSubmission } from '@/lib/redis-community-submissions';
-import { addCommunity } from '@/lib/redis-communities';
+import { getSubmissionById } from '@/lib/redis-community-submissions';
+import { approveSubmissionAtomic } from '@/lib/redis-community-submissions';
 import type { Community } from '@/types/community';
 
 function slugify(name: string): string {
@@ -42,17 +42,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
     }
 
-    // Mark as approved
-    await updateSubmission(id, {
-      verification_status: 'approved',
-      reviewed_by: session.user.email,
-      reviewed_at: new Date().toISOString(),
-    });
-
-    // Convert to Community
     const now = new Date().toISOString();
+    const communityId = `community-${crypto.randomUUID()}`;
     const community: Community = {
-      id: `community-${Date.now()}`,
+      id: communityId,
       name: submission.name,
       slug: slugify(submission.name),
       city: submission.city,
@@ -62,7 +55,7 @@ export async function POST(request: NextRequest) {
       coordinates: submission.coordinates ?? { lat: 0, lng: 0 },
       organizers: [
         {
-          id: `org-${Date.now()}`,
+          id: `org-${crypto.randomUUID()}`,
           name: submission.organizer_name,
           role: 'Lead Organizer',
         },
@@ -79,18 +72,15 @@ export async function POST(request: NextRequest) {
       status: 'new',
       invite_only: false,
       verified: false,
-      verification_status: 'pending',
+      verification_status: 'verified',
       cois_tier: 'none',
       created_at: now,
       updated_at: now,
     };
 
-    await addCommunity(community);
+    await approveSubmissionAtomic(id, community);
 
-    // Remove from submissions queue
-    await deleteSubmission(id);
-
-    return NextResponse.json({ success: true, communityId: community.id });
+    return NextResponse.json({ success: true, communityId });
   } catch (error: unknown) {
     console.error('Error approving submission:', error);
     return NextResponse.json({ error: 'Failed to approve' }, { status: 500 });

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -1,0 +1,98 @@
+/**
+ * Approve Community Submission API
+ * POST /api/admin/community-submissions/approve
+ *
+ * Converts a pending submission into a full Community in Redis.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { UserManagementService } from '@/lib/admin/user-management-service';
+import { getSubmissionById, updateSubmission, deleteSubmission } from '@/lib/redis-community-submissions';
+import { addCommunity } from '@/lib/redis-communities';
+import type { Community } from '@/types/community';
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const isAdmin = await UserManagementService.isAdmin(session.user.email);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const { id } = await request.json();
+    if (!id) {
+      return NextResponse.json({ error: 'Submission ID required' }, { status: 400 });
+    }
+
+    const submission = await getSubmissionById(id);
+    if (!submission) {
+      return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
+    }
+
+    // Mark as approved
+    await updateSubmission(id, {
+      verification_status: 'approved',
+      reviewed_by: session.user.email,
+      reviewed_at: new Date().toISOString(),
+    });
+
+    // Convert to Community
+    const now = new Date().toISOString();
+    const community: Community = {
+      id: `community-${Date.now()}`,
+      name: submission.name,
+      slug: slugify(submission.name),
+      city: submission.city,
+      country: submission.country,
+      region: submission.region,
+      timezone: submission.timezone ?? 'UTC',
+      coordinates: submission.coordinates ?? { lat: 0, lng: 0 },
+      organizers: [
+        {
+          id: `org-${Date.now()}`,
+          name: submission.organizer_name,
+          role: 'Lead Organizer',
+        },
+      ],
+      founded_date: now,
+      event_types: ['meetup'],
+      website: submission.website,
+      meetup_url: submission.meetup_url,
+      description: submission.description,
+      member_count: submission.member_count ?? 0,
+      typical_attendance: 0,
+      meeting_frequency: 'monthly',
+      primary_language: 'English',
+      status: 'new',
+      invite_only: false,
+      verified: false,
+      verification_status: 'pending',
+      cois_tier: 'none',
+      created_at: now,
+      updated_at: now,
+    };
+
+    await addCommunity(community);
+
+    // Remove from submissions queue
+    await deleteSubmission(id);
+
+    return NextResponse.json({ success: true, communityId: community.id });
+  } catch (error: unknown) {
+    console.error('Error approving submission:', error);
+    return NextResponse.json({ error: 'Failed to approve' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/community-submissions/reject/route.ts
+++ b/src/app/api/admin/community-submissions/reject/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Reject Community Submission API
+ * POST /api/admin/community-submissions/reject
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { UserManagementService } from '@/lib/admin/user-management-service';
+import { getSubmissionById, updateSubmission } from '@/lib/redis-community-submissions';
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const isAdmin = await UserManagementService.isAdmin(session.user.email);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const { id, reason } = await request.json();
+    if (!id) {
+      return NextResponse.json({ error: 'Submission ID required' }, { status: 400 });
+    }
+
+    const submission = await getSubmissionById(id);
+    if (!submission) {
+      return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
+    }
+
+    await updateSubmission(id, {
+      verification_status: 'rejected',
+      reviewed_by: session.user.email,
+      reviewed_at: new Date().toISOString(),
+      rejection_reason: reason || undefined,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    console.error('Error rejecting submission:', error);
+    return NextResponse.json({ error: 'Failed to reject' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/community-submissions/route.ts
+++ b/src/app/api/admin/community-submissions/route.ts
@@ -1,0 +1,32 @@
+/**
+ * List Community Submissions API
+ * GET /api/admin/community-submissions
+ */
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { UserManagementService } from '@/lib/admin/user-management-service';
+import { getSubmissions } from '@/lib/redis-community-submissions';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    const isAdmin = await UserManagementService.isAdmin(session.user.email);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const submissions = await getSubmissions();
+    return NextResponse.json({ submissions });
+  } catch (error: unknown) {
+    console.error('Error fetching submissions:', error);
+    return NextResponse.json({ error: 'Failed to fetch submissions' }, { status: 500 });
+  }
+}

--- a/src/app/api/communities/submit/route.ts
+++ b/src/app/api/communities/submit/route.ts
@@ -6,10 +6,11 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { saveSubmission } from '@/lib/redis-community-submissions';
+import type { CommunitySubmission } from '@/types/community-submission';
 
 export async function POST(request: Request) {
   try {
-    // Verify authentication
     const session = await getServerSession(authOptions);
 
     if (!session?.user?.email) {
@@ -21,7 +22,6 @@ export async function POST(request: Request) {
 
     const body = await request.json();
 
-    // Validate required fields
     const required = ['name', 'address', 'city', 'country', 'description', 'organizer_name', 'organizer_email'];
     for (const field of required) {
       if (!body[field]) {
@@ -32,8 +32,8 @@ export async function POST(request: Request) {
       }
     }
 
-    // Create submission record
-    const submission = {
+    const now = new Date().toISOString();
+    const submission: CommunitySubmission = {
       id: `submission-${Date.now()}`,
       name: body.name,
       address: body.address,
@@ -48,25 +48,20 @@ export async function POST(request: Request) {
       submitted_by: session.user.email,
       verification_status: 'pending',
       geocoded: false,
-      submitted_at: new Date().toISOString(),
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
+      submitted_at: now,
+      created_at: now,
+      updated_at: now,
     };
 
-    console.log('📝 New community submission:', submission);
-
-    // TODO: Store in Redis pending queue: pending_communities:{id}
-    // TODO: Geocode address to get coordinates
-    // TODO: Send email notification to admins
-    // TODO: Add to admin review queue
+    await saveSubmission(submission);
 
     return NextResponse.json({
       success: true,
       message: 'Community submitted successfully. We will review and add it soon!',
     });
 
-  } catch (error: any) {
-    console.error('❌ Community submission failed:', error);
+  } catch (error: unknown) {
+    console.error('Community submission failed:', error);
     return NextResponse.json(
       { success: false, error: 'Submission failed' },
       { status: 500 }

--- a/src/app/api/communities/submit/route.ts
+++ b/src/app/api/communities/submit/route.ts
@@ -32,6 +32,20 @@ export async function POST(request: Request) {
       }
     }
 
+    const maxLengths: Record<string, number> = {
+      name: 200, address: 500, city: 100, country: 100,
+      description: 2000, organizer_name: 200, organizer_email: 254,
+      meetup_url: 500, website: 500,
+    };
+    for (const [field, max] of Object.entries(maxLengths)) {
+      if (typeof body[field] === 'string' && body[field].length > max) {
+        return NextResponse.json(
+          { success: false, error: `${field} exceeds ${max} characters` },
+          { status: 400 }
+        );
+      }
+    }
+
     const now = new Date().toISOString();
     const submission: CommunitySubmission = {
       id: `submission-${crypto.randomUUID()}`,

--- a/src/app/api/communities/submit/route.ts
+++ b/src/app/api/communities/submit/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
 
     const now = new Date().toISOString();
     const submission: CommunitySubmission = {
-      id: `submission-${Date.now()}`,
+      id: `submission-${crypto.randomUUID()}`,
       name: body.name,
       address: body.address,
       city: body.city,

--- a/src/app/communities/[slug]/page.tsx
+++ b/src/app/communities/[slug]/page.tsx
@@ -282,10 +282,12 @@ export default async function CommunityPage({ params }: CommunityPageProps) {
                 </h3>
                 <div className="space-y-3 text-sm">
                   <InfoRow label="Timezone" value={community.timezone} />
-                  <InfoRow
-                    label="Location"
-                    value={`${community.coordinates.lat.toFixed(4)}, ${community.coordinates.lng.toFixed(4)}`}
-                  />
+                  {community.coordinates && (
+                    <InfoRow
+                      label="Location"
+                      value={`${community.coordinates.lat.toFixed(4)}, ${community.coordinates.lng.toFixed(4)}`}
+                    />
+                  )}
                   {community.founded_date && (
                     <InfoRow
                       label="Founded"

--- a/src/components/admin/PendingSubmissionsTable.tsx
+++ b/src/components/admin/PendingSubmissionsTable.tsx
@@ -19,9 +19,11 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
+  const [errorId, setErrorId] = useState<string | null>(null);
 
   async function handleApprove(id: string) {
     setLoadingId(id);
+    setErrorId(null);
     try {
       const res = await fetch('/api/admin/community-submissions/approve', {
         method: 'POST',
@@ -30,8 +32,8 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
       });
       if (!res.ok) throw new Error('Failed to approve');
       router.refresh();
-    } catch (err) {
-      console.error('Approve failed:', err);
+    } catch {
+      setErrorId(id);
     } finally {
       setLoadingId(null);
     }
@@ -39,6 +41,7 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
 
   async function handleReject(id: string) {
     setLoadingId(id);
+    setErrorId(null);
     try {
       const res = await fetch('/api/admin/community-submissions/reject', {
         method: 'POST',
@@ -49,11 +52,22 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
       setRejectingId(null);
       setRejectReason('');
       router.refresh();
-    } catch (err) {
-      console.error('Reject failed:', err);
+    } catch {
+      setErrorId(id);
     } finally {
       setLoadingId(null);
     }
+  }
+
+  function startReject(id: string) {
+    setRejectingId(id);
+    setRejectReason('');
+    setErrorId(null);
+  }
+
+  function cancelReject() {
+    setRejectingId(null);
+    setRejectReason('');
   }
 
   if (submissions.length === 0) {
@@ -95,6 +109,10 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
             <div>Submitted: {new Date(s.submitted_at).toLocaleDateString()}</div>
           </div>
 
+          {errorId === s.id && (
+            <p className="text-sm text-destructive">Action failed. Please try again.</p>
+          )}
+
           {s.verification_status === 'pending' && (
             <div className="flex items-center gap-2 pt-2 border-t border-border">
               {rejectingId === s.id ? (
@@ -117,7 +135,7 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
                   <RFDS.SemanticButton
                     variant="secondary"
                     size="sm"
-                    onClick={() => { setRejectingId(null); setRejectReason(''); }}
+                    onClick={cancelReject}
                   >
                     Cancel
                   </RFDS.SemanticButton>
@@ -135,7 +153,7 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
                   <RFDS.SemanticButton
                     variant="destructive"
                     size="sm"
-                    onClick={() => setRejectingId(s.id)}
+                    onClick={() => startReject(s.id)}
                     disabled={loadingId === s.id}
                   >
                     Reject

--- a/src/components/admin/PendingSubmissionsTable.tsx
+++ b/src/components/admin/PendingSubmissionsTable.tsx
@@ -1,0 +1,157 @@
+/**
+ * Pending Community Submissions Table
+ * Shows submissions awaiting admin review with approve/reject actions
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { RFDS } from '@/components/rfds';
+import type { CommunitySubmission } from '@/types/community-submission';
+
+interface PendingSubmissionsTableProps {
+  submissions: CommunitySubmission[];
+}
+
+export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTableProps) {
+  const router = useRouter();
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+
+  async function handleApprove(id: string) {
+    setLoadingId(id);
+    try {
+      const res = await fetch('/api/admin/community-submissions/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error('Failed to approve');
+      router.refresh();
+    } catch (err) {
+      console.error('Approve failed:', err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  async function handleReject(id: string) {
+    setLoadingId(id);
+    try {
+      const res = await fetch('/api/admin/community-submissions/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, reason: rejectReason }),
+      });
+      if (!res.ok) throw new Error('Failed to reject');
+      setRejectingId(null);
+      setRejectReason('');
+      router.refresh();
+    } catch (err) {
+      console.error('Reject failed:', err);
+    } finally {
+      setLoadingId(null);
+    }
+  }
+
+  if (submissions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No pending submissions.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {submissions.map((s) => (
+        <div
+          key={s.id}
+          className="border border-border rounded-lg p-4 bg-muted/30 space-y-3"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h4 className="font-semibold text-foreground">{s.name}</h4>
+              <p className="text-sm text-muted-foreground">
+                {s.city}, {s.country}
+              </p>
+            </div>
+            <RFDS.SemanticBadge variant={
+              s.verification_status === 'pending' ? 'warning' :
+              s.verification_status === 'rejected' ? 'destructive' : 'success'
+            }>
+              {s.verification_status}
+            </RFDS.SemanticBadge>
+          </div>
+
+          <p className="text-sm text-foreground">{s.description}</p>
+
+          <div className="grid grid-cols-2 gap-2 text-sm text-muted-foreground">
+            <div>Organizer: {s.organizer_name} ({s.organizer_email})</div>
+            <div>Submitted by: {s.submitted_by}</div>
+            {s.website && <div>Website: {s.website}</div>}
+            {s.meetup_url && <div>Meetup: {s.meetup_url}</div>}
+            {s.member_count ? <div>Members: {s.member_count}</div> : null}
+            <div>Submitted: {new Date(s.submitted_at).toLocaleDateString()}</div>
+          </div>
+
+          {s.verification_status === 'pending' && (
+            <div className="flex items-center gap-2 pt-2 border-t border-border">
+              {rejectingId === s.id ? (
+                <div className="flex items-center gap-2 flex-1">
+                  <input
+                    type="text"
+                    placeholder="Reason (optional)"
+                    value={rejectReason}
+                    onChange={(e) => setRejectReason(e.target.value)}
+                    className="flex-1 px-3 py-1.5 text-sm border border-border rounded-lg bg-background text-foreground"
+                  />
+                  <RFDS.SemanticButton
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleReject(s.id)}
+                    disabled={loadingId === s.id}
+                  >
+                    {loadingId === s.id ? 'Rejecting...' : 'Confirm'}
+                  </RFDS.SemanticButton>
+                  <RFDS.SemanticButton
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => { setRejectingId(null); setRejectReason(''); }}
+                  >
+                    Cancel
+                  </RFDS.SemanticButton>
+                </div>
+              ) : (
+                <>
+                  <RFDS.SemanticButton
+                    variant="primary"
+                    size="sm"
+                    onClick={() => handleApprove(s.id)}
+                    disabled={loadingId === s.id}
+                  >
+                    {loadingId === s.id ? 'Approving...' : 'Approve'}
+                  </RFDS.SemanticButton>
+                  <RFDS.SemanticButton
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setRejectingId(s.id)}
+                    disabled={loadingId === s.id}
+                  >
+                    Reject
+                  </RFDS.SemanticButton>
+                </>
+              )}
+            </div>
+          )}
+
+          {s.verification_status === 'rejected' && s.rejection_reason && (
+            <p className="text-sm text-destructive pt-2 border-t border-border">
+              Rejected: {s.rejection_reason}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/communities/CommunityMap.tsx
+++ b/src/components/communities/CommunityMap.tsx
@@ -284,13 +284,13 @@ export function CommunityMap() {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
 
-        {communities.map((community) => {
+        {communities.filter((c) => c.coordinates).map((community) => {
           const iconOptions = createCustomIcon(community.cois_tier, community.status);
 
           return (
             <Marker
               key={community.id}
-              position={[community.coordinates.lat, community.coordinates.lng]}
+              position={[community.coordinates!.lat, community.coordinates!.lng]}
               icon={
                 iconOptions && L
                   ? L.divIcon(iconOptions)

--- a/src/lib/redis-community-submissions.ts
+++ b/src/lib/redis-community-submissions.ts
@@ -69,24 +69,37 @@ export async function updateSubmission(
   const redis = await getRedis();
   if (!redis) throw new Error('Redis not available');
 
-  const existing = await redis.get(getSubmissionKey(id));
-  if (!existing) throw new Error(`Submission ${id} not found`);
+  const key = getSubmissionKey(id);
+
+  // WATCH key for optimistic locking — if another request modifies
+  // the key between GET and EXEC, the transaction aborts.
+  await redis.watch(key);
+
+  const existing = await redis.get(key);
+  if (!existing) {
+    await redis.unwatch();
+    throw new Error(`Submission ${id} not found`);
+  }
 
   const submission = JSON.parse(existing) as CommunitySubmission;
   const updated: CommunitySubmission = {
     ...submission,
     ...updates,
-    id, // prevent ID changes
+    id,
     updated_at: new Date().toISOString(),
   };
 
-  await redis.set(getSubmissionKey(id), JSON.stringify(updated));
+  const result = await redis.multi().set(key, JSON.stringify(updated)).exec();
+  if (!result) {
+    throw new Error(`Concurrent modification on submission ${id}, retry`);
+  }
+
   return updated;
 }
 
 /**
- * Atomically: add community to Redis + remove submission from queue.
- * Single pipeline ensures no partial state if one op fails.
+ * Atomically add community to Redis + remove submission from queue.
+ * Uses MULTI/EXEC transaction so all ops succeed or none do.
  */
 export async function approveSubmissionAtomic(
   submissionId: string,
@@ -95,14 +108,12 @@ export async function approveSubmissionAtomic(
   const redis = await getRedis();
   if (!redis) throw new Error('Redis not available');
 
-  const pipeline = redis.pipeline();
-  // Add community
-  pipeline.set(`communities:${community.id}`, JSON.stringify(community));
-  pipeline.sadd('communities:index', community.id);
-  // Remove submission
-  pipeline.del(getSubmissionKey(submissionId));
-  pipeline.srem(SUBMISSIONS_INDEX_KEY, submissionId);
-  await pipeline.exec();
+  const tx = redis.multi();
+  tx.set(`communities:${community.id}`, JSON.stringify(community));
+  tx.sadd('communities:index', community.id);
+  tx.del(getSubmissionKey(submissionId));
+  tx.srem(SUBMISSIONS_INDEX_KEY, submissionId);
+  await tx.exec();
 }
 
 export async function deleteSubmission(id: string): Promise<void> {

--- a/src/lib/redis-community-submissions.ts
+++ b/src/lib/redis-community-submissions.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CommunitySubmission } from '@/types/community-submission';
+import type { Community } from '@/types/community';
 
 const SUBMISSIONS_INDEX_KEY = 'community_submissions:index';
 const SUBMISSION_KEY_PREFIX = 'community_submissions:';
@@ -44,7 +45,10 @@ export async function getSubmissions(): Promise<CommunitySubmission[]> {
   if (ids.length === 0) return [];
 
   const keys = ids.map(id => getSubmissionKey(id));
-  const values = await redis.mget(...keys);
+  const pipeline = redis.pipeline();
+  keys.forEach(k => pipeline.get(k));
+  const results = await pipeline.exec();
+  const values = results?.map(([, v]) => v as string | null) ?? [];
 
   return values
     .filter((v): v is string => v !== null)
@@ -103,17 +107,30 @@ export async function updateSubmission(
  */
 export async function approveSubmissionAtomic(
   submissionId: string,
-  community: import('@/types/community').Community
+  community: Community
 ): Promise<void> {
   const redis = await getRedis();
   if (!redis) throw new Error('Redis not available');
 
-  const tx = redis.multi();
-  tx.set(`communities:${community.id}`, JSON.stringify(community));
-  tx.sadd('communities:index', community.id);
-  tx.del(getSubmissionKey(submissionId));
-  tx.srem(SUBMISSIONS_INDEX_KEY, submissionId);
-  await tx.exec();
+  const submissionKey = getSubmissionKey(submissionId);
+  await redis.watch(submissionKey);
+
+  const existing = await redis.get(submissionKey);
+  if (!existing) {
+    await redis.unwatch();
+    throw new Error('Submission already processed');
+  }
+
+  const result = await redis.multi()
+    .set(`communities:${community.id}`, JSON.stringify(community))
+    .sadd('communities:index', community.id)
+    .del(submissionKey)
+    .srem(SUBMISSIONS_INDEX_KEY, submissionId)
+    .exec();
+
+  if (!result) {
+    throw new Error('Concurrent approval detected');
+  }
 }
 
 export async function deleteSubmission(id: string): Promise<void> {

--- a/src/lib/redis-community-submissions.ts
+++ b/src/lib/redis-community-submissions.ts
@@ -20,7 +20,8 @@ async function getRedis() {
   try {
     const { getRedisClient } = await import('./redis');
     return getRedisClient();
-  } catch {
+  } catch (error) {
+    console.error('Redis unavailable for community submissions:', error);
     return null;
   }
 }
@@ -42,13 +43,13 @@ export async function getSubmissions(): Promise<CommunitySubmission[]> {
   const ids = await redis.smembers(SUBMISSIONS_INDEX_KEY);
   if (ids.length === 0) return [];
 
-  const values = await Promise.all(
-    ids.map(id => redis.get(getSubmissionKey(id)))
-  );
+  const keys = ids.map(id => getSubmissionKey(id));
+  const values = await redis.mget(...keys);
 
   return values
     .filter((v): v is string => v !== null)
-    .map(v => JSON.parse(v) as CommunitySubmission);
+    .map(v => JSON.parse(v) as CommunitySubmission)
+    .sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
 }
 
 export async function getSubmissionById(id: string): Promise<CommunitySubmission | null> {
@@ -81,6 +82,27 @@ export async function updateSubmission(
 
   await redis.set(getSubmissionKey(id), JSON.stringify(updated));
   return updated;
+}
+
+/**
+ * Atomically: add community to Redis + remove submission from queue.
+ * Single pipeline ensures no partial state if one op fails.
+ */
+export async function approveSubmissionAtomic(
+  submissionId: string,
+  community: import('@/types/community').Community
+): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) throw new Error('Redis not available');
+
+  const pipeline = redis.pipeline();
+  // Add community
+  pipeline.set(`communities:${community.id}`, JSON.stringify(community));
+  pipeline.sadd('communities:index', community.id);
+  // Remove submission
+  pipeline.del(getSubmissionKey(submissionId));
+  pipeline.srem(SUBMISSIONS_INDEX_KEY, submissionId);
+  await pipeline.exec();
 }
 
 export async function deleteSubmission(id: string): Promise<void> {

--- a/src/lib/redis-community-submissions.ts
+++ b/src/lib/redis-community-submissions.ts
@@ -1,0 +1,94 @@
+/**
+ * Redis Community Submission Storage
+ * Stores pending community submissions for admin review
+ *
+ * Storage:
+ * - Individual submissions: community_submissions:{id} (JSON)
+ * - Index set: community_submissions:index (Redis SET of all IDs)
+ */
+
+import type { CommunitySubmission } from '@/types/community-submission';
+
+const SUBMISSIONS_INDEX_KEY = 'community_submissions:index';
+const SUBMISSION_KEY_PREFIX = 'community_submissions:';
+
+function getSubmissionKey(id: string): string {
+  return `${SUBMISSION_KEY_PREFIX}${id}`;
+}
+
+async function getRedis() {
+  try {
+    const { getRedisClient } = await import('./redis');
+    return getRedisClient();
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSubmission(submission: CommunitySubmission): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) throw new Error('Redis not available');
+
+  const pipeline = redis.pipeline();
+  pipeline.set(getSubmissionKey(submission.id), JSON.stringify(submission));
+  pipeline.sadd(SUBMISSIONS_INDEX_KEY, submission.id);
+  await pipeline.exec();
+}
+
+export async function getSubmissions(): Promise<CommunitySubmission[]> {
+  const redis = await getRedis();
+  if (!redis) return [];
+
+  const ids = await redis.smembers(SUBMISSIONS_INDEX_KEY);
+  if (ids.length === 0) return [];
+
+  const values = await Promise.all(
+    ids.map(id => redis.get(getSubmissionKey(id)))
+  );
+
+  return values
+    .filter((v): v is string => v !== null)
+    .map(v => JSON.parse(v) as CommunitySubmission);
+}
+
+export async function getSubmissionById(id: string): Promise<CommunitySubmission | null> {
+  const redis = await getRedis();
+  if (!redis) return null;
+
+  const data = await redis.get(getSubmissionKey(id));
+  if (!data) return null;
+
+  return JSON.parse(data) as CommunitySubmission;
+}
+
+export async function updateSubmission(
+  id: string,
+  updates: Partial<CommunitySubmission>
+): Promise<CommunitySubmission> {
+  const redis = await getRedis();
+  if (!redis) throw new Error('Redis not available');
+
+  const existing = await redis.get(getSubmissionKey(id));
+  if (!existing) throw new Error(`Submission ${id} not found`);
+
+  const submission = JSON.parse(existing) as CommunitySubmission;
+  const updated: CommunitySubmission = {
+    ...submission,
+    ...updates,
+    id, // prevent ID changes
+    updated_at: new Date().toISOString(),
+  };
+
+  await redis.set(getSubmissionKey(id), JSON.stringify(updated));
+  return updated;
+}
+
+export async function deleteSubmission(id: string): Promise<void> {
+  const redis = await getRedis();
+  if (!redis) throw new Error('Redis not available');
+
+  const pipeline = redis.pipeline();
+  pipeline.del(getSubmissionKey(id));
+  pipeline.srem(SUBMISSIONS_INDEX_KEY, id);
+  await pipeline.exec();
+}

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -13,7 +13,7 @@ export interface Community {
   country: string;
   region?: string; // State/Province
   timezone: string;
-  coordinates: {
+  coordinates?: {
     lat: number;
     lng: number;
   };


### PR DESCRIPTION
## Summary
- Community form submissions now persist to Redis (`community_submissions:{id}`)
- Admin communities page shows pending submissions with approve/reject actions
- Approve converts submission to full Community in Redis; reject stores reason

## Test plan
- [ ] Submit a community via the public form, verify it appears in admin dash
- [ ] Approve a submission, verify it appears in the communities table
- [ ] Reject a submission with a reason, verify status updates