### PR TITLE
[codex] Harden community submission review flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  redis:
+    image: redis/redis-stack:latest
+    ports:
+      - "6379:6379"
+      - "8001:8001" # RedisInsight UI
+    volumes:
+      - redis-data:/data
+    environment:
+      - REDIS_ARGS=--appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis-data:

--- a/src/app/admin/data/communities/page.tsx
+++ b/src/app/admin/data/communities/page.tsx
@@ -1,8 +1,4 @@
-/**
- * Admin Data Communities Page
- * Shows community data and management
- */
-
+// Admin communities page — stats, pending submissions, community list
 import { getRedisClient } from '@/lib/redis';
 import { getCommunities, migrateFromOldFormat } from '@/lib/redis-communities';
 import { getSubmissions } from '@/lib/redis-community-submissions';

--- a/src/app/api/admin/community-submissions/approve/route.ts
+++ b/src/app/api/admin/community-submissions/approve/route.ts
@@ -1,16 +1,30 @@
-/**
- * Approve Community Submission API
- * POST /api/admin/community-submissions/approve
- *
- * Converts a pending submission into a full Community in Redis.
- */
-
+// POST /api/admin/community-submissions/approve — convert submission to Community
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { UserManagementService } from '@/lib/admin/user-management-service';
 import { getSubmissionById, approveSubmissionAtomic } from '@/lib/redis-community-submissions';
 import type { Community } from '@/types/community';
+
+const SUBMISSION_ID_RE = /^submission-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function approvalErrorResponse(error: unknown) {
+  const message = error instanceof Error ? error.message : '';
+
+  if (message.includes('already processed')) {
+    return NextResponse.json({ error: 'Submission already processed' }, { status: 409 });
+  }
+
+  if (message.includes('transaction aborted')) {
+    return NextResponse.json({ error: 'Concurrent approval detected' }, { status: 409 });
+  }
+
+  if (message.includes('Could not generate slug')) {
+    return NextResponse.json({ error: 'Invalid community name' }, { status: 400 });
+  }
+
+  return NextResponse.json({ error: 'Failed to approve submission' }, { status: 500 });
+}
 
 function slugify(name: string): string {
   const slug = name
@@ -34,8 +48,8 @@ export async function POST(request: NextRequest) {
     }
 
     const { id } = await request.json();
-    if (!id) {
-      return NextResponse.json({ error: 'Submission ID required' }, { status: 400 });
+    if (!id || typeof id !== 'string' || !SUBMISSION_ID_RE.test(id)) {
+      return NextResponse.json({ error: 'Invalid submission ID' }, { status: 400 });
     }
 
     const submission = await getSubmissionById(id);
@@ -75,6 +89,8 @@ export async function POST(request: NextRequest) {
       verified: true,
       verification_status: 'verified',
       cois_tier: 'none',
+      approved_by: session.user.email,
+      approved_at: now,
       created_at: now,
       updated_at: now,
     };
@@ -83,9 +99,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true, communityId });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to approve';
-    const status = message.includes('Concurrent') || message.includes('already processed') ? 409 : 500;
     console.error('Error approving submission:', error);
-    return NextResponse.json({ error: message }, { status });
+    return approvalErrorResponse(error);
   }
 }

--- a/src/app/api/admin/community-submissions/reject/route.ts
+++ b/src/app/api/admin/community-submissions/reject/route.ts
@@ -1,13 +1,21 @@
-/**
- * Reject Community Submission API
- * POST /api/admin/community-submissions/reject
- */
-
+// POST /api/admin/community-submissions/reject
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { UserManagementService } from '@/lib/admin/user-management-service';
 import { getSubmissionById, updateSubmission } from '@/lib/redis-community-submissions';
+
+const SUBMISSION_ID_RE = /^submission-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function rejectionErrorResponse(error: unknown) {
+  const message = error instanceof Error ? error.message : '';
+
+  if (message.includes('transaction aborted')) {
+    return NextResponse.json({ error: 'Concurrent rejection detected' }, { status: 409 });
+  }
+
+  return NextResponse.json({ error: 'Failed to reject submission' }, { status: 500 });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,8 +30,8 @@ export async function POST(request: NextRequest) {
     }
 
     const { id, reason } = await request.json();
-    if (!id) {
-      return NextResponse.json({ error: 'Submission ID required' }, { status: 400 });
+    if (!id || typeof id !== 'string' || !SUBMISSION_ID_RE.test(id)) {
+      return NextResponse.json({ error: 'Invalid submission ID' }, { status: 400 });
     }
 
     const submission = await getSubmissionById(id);
@@ -41,6 +49,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true });
   } catch (error: unknown) {
     console.error('Error rejecting submission:', error);
-    return NextResponse.json({ error: 'Failed to reject' }, { status: 500 });
+    return rejectionErrorResponse(error);
   }
 }

--- a/src/app/api/communities/submit/route.ts
+++ b/src/app/api/communities/submit/route.ts
@@ -1,8 +1,4 @@
-/**
- * Community Submission API
- * POST /api/communities/submit - Submit a new community for review
- */
-
+// POST /api/communities/submit — public endpoint for community submissions
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';

--- a/src/components/admin/PendingSubmissionsTable.tsx
+++ b/src/components/admin/PendingSubmissionsTable.tsx
@@ -1,8 +1,4 @@
-/**
- * Pending Community Submissions Table
- * Shows submissions awaiting admin review with approve/reject actions
- */
-
+// Admin table for reviewing pending community submissions
 'use client';
 
 import { useState } from 'react';
@@ -16,58 +12,58 @@ interface PendingSubmissionsTableProps {
 
 export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTableProps) {
   const router = useRouter();
-  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [approvingId, setApprovingId] = useState<string | null>(null);
+  const [rejectFormId, setRejectFormId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
-  const [errorId, setErrorId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<{ id: string; message: string } | null>(null);
+
+  const isBusy = (id: string) => approvingId === id || rejectingId === id;
 
   async function handleApprove(id: string) {
-    setLoadingId(id);
-    setErrorId(null);
+    setApprovingId(id);
+    setErrorMsg(null);
     try {
       const res = await fetch('/api/admin/community-submissions/approve', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id }),
       });
-      if (!res.ok) throw new Error('Failed to approve');
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Failed to approve (${res.status})`);
+      }
       router.refresh();
-    } catch {
-      setErrorId(id);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Action failed';
+      setErrorMsg({ id, message });
     } finally {
-      setLoadingId(null);
+      setApprovingId(null);
     }
   }
 
   async function handleReject(id: string) {
-    setLoadingId(id);
-    setErrorId(null);
+    setRejectingId(id);
+    setErrorMsg(null);
     try {
       const res = await fetch('/api/admin/community-submissions/reject', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id, reason: rejectReason }),
       });
-      if (!res.ok) throw new Error('Failed to reject');
-      setRejectingId(null);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Failed to reject (${res.status})`);
+      }
+      setRejectFormId(null);
       setRejectReason('');
       router.refresh();
-    } catch {
-      setErrorId(id);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Action failed';
+      setErrorMsg({ id, message });
     } finally {
-      setLoadingId(null);
+      setRejectingId(null);
     }
-  }
-
-  function startReject(id: string) {
-    setRejectingId(id);
-    setRejectReason('');
-    setErrorId(null);
-  }
-
-  function cancelReject() {
-    setRejectingId(null);
-    setRejectReason('');
   }
 
   if (submissions.length === 0) {
@@ -109,13 +105,13 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
             <div>Submitted: {new Date(s.submitted_at).toLocaleDateString()}</div>
           </div>
 
-          {errorId === s.id && (
-            <p className="text-sm text-destructive">Action failed. Please try again.</p>
+          {errorMsg?.id === s.id && (
+            <p className="text-sm text-destructive">{errorMsg.message}</p>
           )}
 
           {s.verification_status === 'pending' && (
             <div className="flex items-center gap-2 pt-2 border-t border-border">
-              {rejectingId === s.id ? (
+              {rejectFormId === s.id ? (
                 <div className="flex items-center gap-2 flex-1">
                   <input
                     type="text"
@@ -128,14 +124,15 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
                     variant="destructive"
                     size="sm"
                     onClick={() => handleReject(s.id)}
-                    disabled={loadingId === s.id}
+                    disabled={isBusy(s.id)}
                   >
-                    {loadingId === s.id ? 'Rejecting...' : 'Confirm'}
+                    {rejectingId === s.id ? 'Rejecting...' : 'Confirm'}
                   </RFDS.SemanticButton>
                   <RFDS.SemanticButton
                     variant="secondary"
                     size="sm"
-                    onClick={cancelReject}
+                    onClick={() => { setRejectFormId(null); setRejectReason(''); }}
+                    disabled={rejectingId === s.id}
                   >
                     Cancel
                   </RFDS.SemanticButton>
@@ -146,15 +143,15 @@ export function PendingSubmissionsTable({ submissions }: PendingSubmissionsTable
                     variant="primary"
                     size="sm"
                     onClick={() => handleApprove(s.id)}
-                    disabled={loadingId === s.id}
+                    disabled={isBusy(s.id)}
                   >
-                    {loadingId === s.id ? 'Approving...' : 'Approve'}
+                    {approvingId === s.id ? 'Approving...' : 'Approve'}
                   </RFDS.SemanticButton>
                   <RFDS.SemanticButton
                     variant="destructive"
                     size="sm"
-                    onClick={() => startReject(s.id)}
-                    disabled={loadingId === s.id}
+                    onClick={() => { setRejectFormId(s.id); setRejectReason(''); setErrorMsg(null); }}
+                    disabled={isBusy(s.id)}
                   >
                     Reject
                   </RFDS.SemanticButton>

--- a/src/components/communities/CommunityMap.tsx
+++ b/src/components/communities/CommunityMap.tsx
@@ -1,13 +1,9 @@
-/**
- * Community Map Component
- * Interactive Leaflet map showing React communities worldwide
- */
-
 'use client';
 
 import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import type { Community } from '@/types/community';
+import type * as Leaflet from 'leaflet';
 import useSWR from 'swr';
 
 // Fetcher for SWR
@@ -156,7 +152,7 @@ const FALLBACK_COMMUNITIES: Community[] = [
 
 export function CommunityMap() {
   const [isClient, setIsClient] = useState(false);
-  const [L, setL] = useState<any>(null);
+  const [L, setL] = useState<typeof Leaflet | null>(null);
 
   // Fetch communities from API
   const { data, error, isLoading } = useSWR(
@@ -171,16 +167,16 @@ export function CommunityMap() {
   const communities: Community[] = data?.communities || FALLBACK_COMMUNITIES;
 
   useEffect(() => {
-    console.log('🗺️ CommunityMap: Component mounted');
-    console.log('🗺️ Communities loaded:', communities.length);
-
     // Load Leaflet
     if (typeof window !== 'undefined') {
       import('leaflet').then((LeafletModule) => {
         const LeafletLib = LeafletModule.default;
+        type IconDefaultPrototype = typeof LeafletLib.Icon.Default.prototype & {
+          _getIconUrl?: unknown;
+        };
 
         // Fix default marker icon issue in Next.js
-        delete (LeafletLib.Icon.Default.prototype as any)._getIconUrl;
+        delete (LeafletLib.Icon.Default.prototype as IconDefaultPrototype)._getIconUrl;
         LeafletLib.Icon.Default.mergeOptions({
           iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
           iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
@@ -284,13 +280,15 @@ export function CommunityMap() {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
 
-        {communities.filter((c) => c.coordinates).map((community) => {
+        {communities
+          .filter((c): c is Community & { coordinates: NonNullable<Community['coordinates']> } => !!c.coordinates)
+          .map((community) => {
           const iconOptions = createCustomIcon(community.cois_tier, community.status);
 
           return (
             <Marker
               key={community.id}
-              position={[community.coordinates!.lat, community.coordinates!.lng]}
+              position={[community.coordinates.lat, community.coordinates.lng]}
               icon={
                 iconOptions && L
                   ? L.divIcon(iconOptions)

--- a/src/lib/redis-community-submissions.ts
+++ b/src/lib/redis-community-submissions.ts
@@ -1,17 +1,10 @@
-/**
- * Redis Community Submission Storage
- * Stores pending community submissions for admin review
- *
- * Storage:
- * - Individual submissions: community_submissions:{id} (JSON)
- * - Index set: community_submissions:index (Redis SET of all IDs)
- */
-
+// Redis storage for pending community submissions (admin review queue)
 import type { CommunitySubmission } from '@/types/community-submission';
 import type { Community } from '@/types/community';
 
 const SUBMISSIONS_INDEX_KEY = 'community_submissions:index';
 const SUBMISSION_KEY_PREFIX = 'community_submissions:';
+type RedisExecResult = Array<[Error | null, unknown]>;
 
 function getSubmissionKey(id: string): string {
   return `${SUBMISSION_KEY_PREFIX}${id}`;
@@ -27,6 +20,19 @@ async function getRedis() {
   }
 }
 
+function assertRedisExecSucceeded(results: RedisExecResult | null, operation: string): RedisExecResult {
+  if (!results) {
+    throw new Error(`Redis transaction aborted while trying to ${operation}`);
+  }
+
+  const failed = results.find(([error]) => error !== null);
+  if (failed?.[0]) {
+    throw failed[0];
+  }
+
+  return results;
+}
+
 export async function saveSubmission(submission: CommunitySubmission): Promise<void> {
   const redis = await getRedis();
   if (!redis) throw new Error('Redis not available');
@@ -34,7 +40,7 @@ export async function saveSubmission(submission: CommunitySubmission): Promise<v
   const pipeline = redis.pipeline();
   pipeline.set(getSubmissionKey(submission.id), JSON.stringify(submission));
   pipeline.sadd(SUBMISSIONS_INDEX_KEY, submission.id);
-  await pipeline.exec();
+  assertRedisExecSucceeded(await pipeline.exec(), 'save submission');
 }
 
 export async function getSubmissions(): Promise<CommunitySubmission[]> {
@@ -47,12 +53,19 @@ export async function getSubmissions(): Promise<CommunitySubmission[]> {
   const keys = ids.map(id => getSubmissionKey(id));
   const pipeline = redis.pipeline();
   keys.forEach(k => pipeline.get(k));
-  const results = await pipeline.exec();
-  const values = results?.map(([, v]) => v as string | null) ?? [];
+  const results = assertRedisExecSucceeded(await pipeline.exec(), 'load submissions');
+  const values = results.map(([, v]) => v as string | null);
 
   return values
     .filter((v): v is string => v !== null)
-    .map(v => JSON.parse(v) as CommunitySubmission)
+    .reduce<CommunitySubmission[]>((acc, v) => {
+      try {
+        acc.push(JSON.parse(v) as CommunitySubmission);
+      } catch {
+        console.error('Skipping malformed submission record in Redis');
+      }
+      return acc;
+    }, [])
     .sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
 }
 
@@ -93,18 +106,15 @@ export async function updateSubmission(
     updated_at: new Date().toISOString(),
   };
 
-  const result = await redis.multi().set(key, JSON.stringify(updated)).exec();
-  if (!result) {
-    throw new Error(`Concurrent modification on submission ${id}, retry`);
-  }
+  assertRedisExecSucceeded(
+    await redis.multi().set(key, JSON.stringify(updated)).exec(),
+    `update submission ${id}`
+  );
 
   return updated;
 }
 
-/**
- * Atomically add community to Redis + remove submission from queue.
- * Uses MULTI/EXEC transaction so all ops succeed or none do.
- */
+// Atomically add community to Redis + remove submission from queue
 export async function approveSubmissionAtomic(
   submissionId: string,
   community: Community
@@ -121,16 +131,15 @@ export async function approveSubmissionAtomic(
     throw new Error('Submission already processed');
   }
 
-  const result = await redis.multi()
-    .set(`communities:${community.id}`, JSON.stringify(community))
-    .sadd('communities:index', community.id)
-    .del(submissionKey)
-    .srem(SUBMISSIONS_INDEX_KEY, submissionId)
-    .exec();
-
-  if (!result) {
-    throw new Error('Concurrent approval detected');
-  }
+  assertRedisExecSucceeded(
+    await redis.multi()
+      .set(`communities:${community.id}`, JSON.stringify(community))
+      .sadd('communities:index', community.id)
+      .del(submissionKey)
+      .srem(SUBMISSIONS_INDEX_KEY, submissionId)
+      .exec(),
+    `approve submission ${submissionId}`
+  );
 }
 
 export async function deleteSubmission(id: string): Promise<void> {
@@ -140,5 +149,5 @@ export async function deleteSubmission(id: string): Promise<void> {
   const pipeline = redis.pipeline();
   pipeline.del(getSubmissionKey(id));
   pipeline.srem(SUBMISSIONS_INDEX_KEY, id);
-  await pipeline.exec();
+  assertRedisExecSucceeded(await pipeline.exec(), `delete submission ${id}`);
 }

--- a/src/types/community-submission.ts
+++ b/src/types/community-submission.ts
@@ -1,8 +1,3 @@
-/**
- * Community Submission Types
- * For pending community submissions awaiting verification
- */
-
 export interface CommunitySubmission {
   id: string;
 

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,8 +1,3 @@
-/**
- * Community Types
- * For React community finder and organizer profiles
- */
-
 export interface Community {
   id: string;
   name: string;
@@ -50,6 +45,10 @@ export interface Community {
   cois_tier?: 'platinum' | 'gold' | 'silver' | 'bronze' | 'none';
   cois_score?: number;
   last_event_date?: string;
+
+  // Audit trail
+  approved_by?: string;
+  approved_at?: string;
 
   // Metadata
   created_at: string;


### PR DESCRIPTION
## Summary

Cleans up the saved community-submission stash into a focused PR:

- validates admin submission IDs before approve/reject actions
- records approval audit metadata on approved communities
- improves pending-submission row loading and error states
- checks Redis pipeline and transaction command errors consistently
- skips malformed submission records instead of crashing the pending queue
- removes noisy header comments while keeping behavior-focused comments
- adds local Redis Stack docker-compose support for testing the queue locally

## Evaluation

The main cleanup risk was Redis transaction handling: non-null EXEC results can still contain per-command errors, so the implementation now checks tuple errors for pipelines and transactions. Admin routes now return stable public messages for unexpected server failures while logging details server-side.

## Test Plan

- ESLint on changed TypeScript files
- git diff --check --cached

## Not Tested

- Full tsc --noEmit is blocked by an existing stale .next/types reference to src/app/budgets/2026/page.js
- Manual Redis approve/reject flow