### PR TITLE
Fix: add Docusaurus to RIS tracking (closes #53)

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -42,7 +42,7 @@ curl http://localhost:3000/api/ris/status
 ```
 
 ### [📚 Ecosystem Libraries](./ecosystem-libraries.md)
-Complete list of 54 React ecosystem libraries tracked for RIS:
+Complete list of 55 React ecosystem libraries tracked for RIS:
 - Core libraries (React, React DOM)
 - Routing (React Router, TanStack Router)
 - State management (Redux, Zustand, Jotai)

--- a/docs/development/ecosystem-libraries.md
+++ b/docs/development/ecosystem-libraries.md
@@ -1,6 +1,6 @@
 # React Ecosystem Libraries Tracking
 
-This document outlines the 54 React ecosystem libraries tracked for contributor recognition and tier progression in the React Foundation Store.
+This document outlines the 55 React ecosystem libraries tracked for contributor recognition and tier progression in the React Foundation Store.
 
 ## Overview
 
@@ -31,7 +31,7 @@ With 54 tracked libraries, tier thresholds have been calibrated to recognize mea
 | **Sustainer Access** | 120 | Sustained engagement across multiple libraries (~15 merged PRs) |
 | **Core Ally Access** | 250 | Top-tier maintainers who are pillars of the ecosystem (~30+ merged PRs) |
 
-## Tracked Libraries (54 Total)
+## Tracked Libraries (55 Total)
 
 ### Core React & React Native (9 repositories)
 **Tier 1 (Critical Infrastructure):**
@@ -90,7 +90,7 @@ With 54 tracked libraries, tier thresholds have been calibrated to recognize mea
 
 ---
 
-### Meta-frameworks (5 repositories)
+### Meta-frameworks (6 repositories)
 **Tier 1 (Production-Grade Frameworks):**
 - `vercel/next.js` - The React framework for production
 - `remix-run/remix` - Full-stack web framework
@@ -98,6 +98,7 @@ With 54 tracked libraries, tier thresholds have been calibrated to recognize mea
 
 **Tier 2:**
 - `gatsbyjs/gatsby` - Static site generator
+- `facebook/docusaurus` - Documentation-focused React meta-framework
 - `withastro/astro` - Modern static site builder with React support
 
 ---

--- a/public-context/development/tech-stack.md
+++ b/public-context/development/tech-stack.md
@@ -79,7 +79,7 @@ The React Foundation platform is built with modern web technologies, combining a
 **GitHub APIs**
 - GraphQL API for contribution tracking
 - REST API for user data
-- Tracks 54 React ecosystem libraries
+- Tracks 55 React ecosystem libraries
 - Automatic metric collection
 
 **Redis (Upstash)**

--- a/public-context/faq.md
+++ b/public-context/faq.md
@@ -78,12 +78,12 @@ Yes, but smoothing prevents dramatic drops:
 
 ### Which libraries are tracked for RIS?
 
-54 React ecosystem libraries including:
+55 React ecosystem libraries including:
 - Core: React, React DOM
 - Routing: React Router, TanStack Router
 - State: Redux, Zustand, Jotai, Recoil
 - Data: TanStack Query, SWR, Apollo Client
-- Frameworks: Next.js, Remix, Gatsby
+- Frameworks: Next.js, Remix, Gatsby, Docusaurus
 - UI: Material-UI, Chakra UI, Radix
 - ...and 40+ more
 
@@ -91,7 +91,7 @@ Yes, but smoothing prevents dramatic drops:
 
 ### How do I get my library tracked?
 
-Currently, the 54 libraries are pre-selected based on ecosystem importance. New libraries may be added:
+Currently, the 55 libraries are pre-selected based on ecosystem importance. New libraries may be added:
 - Annual review of ecosystem landscape
 - Community nomination process
 - Board approval required

--- a/public-context/getting-involved/contributor-tracking.md
+++ b/public-context/getting-involved/contributor-tracking.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The React Foundation tracks contributions to 54 React ecosystem libraries via GitHub integration. Contributors earn points and unlock exclusive store access based on their activity.
+The React Foundation tracks contributions to 55 React ecosystem libraries via GitHub integration. Contributors earn points and unlock exclusive store access based on their activity.
 
 **This is separate from RIS** - RIS rewards library maintainers with revenue, while contributor tracking rewards individual developers with store access.
 
@@ -20,7 +20,7 @@ The React Foundation tracks contributions to 54 React ecosystem libraries via Gi
 
 No manual submission - all tracked via GitHub API!
 
-## Tracked Libraries (54 Total)
+## Tracked Libraries (55 Total)
 
 ### Routing & Frameworks
 - **react-router** - React Router
@@ -28,6 +28,7 @@ No manual submission - all tracked via GitHub API!
 - **remix-run/remix** - Remix
 - **vercel/next.js** - Next.js
 - **gatsbyjs/gatsby** - Gatsby
+- **facebook/docusaurus** - Docusaurus
 - **molefrog/wouter** - Wouter
 
 ### State Management

--- a/src/app/profile/contributor-status/page.tsx
+++ b/src/app/profile/contributor-status/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { MaintainerProgress } from "@/features/maintainer-progress/maintainer-progress";
 import { MaintainerProgressProvider } from "@/features/maintainer-progress/context";
 import { Pill } from "@/components/ui/pill";
+import { ecosystemLibraries } from "@/lib/maintainer-tiers";
 
 export const metadata: Metadata = {
   title: "Contributor Status",
@@ -9,6 +10,8 @@ export const metadata: Metadata = {
 };
 
 export default function ContributorStatusPage() {
+  const libraryCount = ecosystemLibraries.length;
+
   return (
     <div className="space-y-8 pt-12">
       <div>
@@ -18,7 +21,7 @@ export default function ContributorStatusPage() {
           <Pill tone="sky">PREVIEW</Pill>
         </div>
         <p className="mt-2 text-base text-foreground/70">
-          Your contributions across 54 React ecosystem libraries.
+          Your contributions across {libraryCount} React ecosystem libraries.
         </p>
       </div>
 

--- a/src/lib/ingest/loaders/libraries.ts
+++ b/src/lib/ingest/loaders/libraries.ts
@@ -4,8 +4,6 @@
  * Based on AUTO_INGESTION_SETUP.md specification
  */
 
-import { readFile } from 'fs/promises';
-import { join } from 'path';
 import type { ContentLoader, RawRecord } from '../types';
 import { logger } from '@/lib/logger';
 
@@ -55,11 +53,12 @@ export class LibrariesLoader implements ContentLoader {
     { repo: 'TanStack/router', name: 'TanStack Router', category: 'Routing', tier: 'Tier 2' },
     { repo: 'molefrog/wouter', name: 'Wouter', category: 'Routing', tier: 'Tier 3' },
 
-    // Meta-frameworks (5 repositories)
+    // Meta-frameworks (6 repositories)
     { repo: 'vercel/next.js', name: 'Next.js', category: 'Meta-frameworks', tier: 'Tier 1' },
     { repo: 'remix-run/remix', name: 'Remix', category: 'Meta-frameworks', tier: 'Tier 1' },
     { repo: 'expo/expo', name: 'Expo', category: 'Meta-frameworks', tier: 'Tier 1' },
     { repo: 'gatsbyjs/gatsby', name: 'Gatsby', category: 'Meta-frameworks', tier: 'Tier 2' },
+    { repo: 'facebook/docusaurus', name: 'Docusaurus', category: 'Meta-frameworks', tier: 'Tier 2' },
     { repo: 'withastro/astro', name: 'Astro', category: 'Meta-frameworks', tier: 'Tier 2' },
 
     // Forms & Validation (5 repositories)

--- a/src/lib/library-icons.tsx
+++ b/src/lib/library-icons.tsx
@@ -16,6 +16,7 @@ import {
   SiTailwindcss,
   SiGraphql,
   SiGatsby,
+  SiDocusaurus,
   SiRemix,
   SiExpo,
   SiZod,
@@ -76,7 +77,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
   remix: SiRemix,
   expo: SiExpo,
   gatsby: SiGatsby,
-  docusaurus: null,
+  docusaurus: SiDocusaurus,
   astro: SiAstro,
 
   // Forms & Validation

--- a/src/lib/library-icons.tsx
+++ b/src/lib/library-icons.tsx
@@ -1,5 +1,5 @@
 /**
- * Icon mapping for all 54 React ecosystem libraries
+ * Icon mapping for all 55 React ecosystem libraries
  * Uses Simple Icons via @icons-pack/react-simple-icons
  */
 
@@ -76,6 +76,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
   remix: SiRemix,
   expo: SiExpo,
   gatsby: SiGatsby,
+  docusaurus: null,
   astro: SiAstro,
 
   // Forms & Validation
@@ -152,6 +153,7 @@ export const libraryDisplayNames: Record<string, string> = {
   remix: "Remix",
   expo: "Expo",
   gatsby: "Gatsby",
+  docusaurus: "Docusaurus",
   astro: "Astro",
   "react-hook-form": "React Hook Form",
   formik: "Formik",

--- a/src/lib/maintainer-tiers.test.ts
+++ b/src/lib/maintainer-tiers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { libraryDisplayNames } from './library-icons';
 import { ecosystemLibraries } from './maintainer-tiers';
+import { LibrariesLoader } from './ingest/loaders/libraries';
 import { NPMCollector } from './ris/collectors/npm-collector';
+import { PROBE_REPOS } from './ris/data/probe-repos';
 
 function findLibrary(owner: string, name: string) {
   return ecosystemLibraries.find((library) => library.owner === owner && library.name === name);
@@ -17,6 +20,10 @@ describe('ecosystemLibraries', () => {
       category: 'data',
       tier: 2,
     });
+    expect(findLibrary('facebook', 'docusaurus')).toMatchObject({
+      category: 'framework',
+      tier: 2,
+    });
   });
 
   it('does not contain duplicate repository targets', () => {
@@ -29,6 +36,28 @@ describe('ecosystemLibraries', () => {
     expect(NPMCollector.getPackageName('ant-design', 'ant-design')).toBe('antd');
     expect(NPMCollector.getPackageName('invertase', 'react-native-firebase')).toBe(
       '@react-native-firebase/app'
+    );
+    expect(NPMCollector.getPackageName('facebook', 'docusaurus')).toBe('@docusaurus/core');
+  });
+
+  it('includes Docusaurus in related library datasets', async () => {
+    expect(libraryDisplayNames.docusaurus).toBe('Docusaurus');
+
+    expect(PROBE_REPOS).toContainEqual(
+      expect.objectContaining({
+        owner: 'facebook',
+        repo: 'docusaurus',
+        category: 'framework',
+      })
+    );
+
+    const loader = new LibrariesLoader();
+    const records = await loader.load();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'library-facebook-docusaurus',
+        title: 'Docusaurus',
+      })
     );
   });
 });

--- a/src/lib/maintainer-tiers.ts
+++ b/src/lib/maintainer-tiers.ts
@@ -80,11 +80,12 @@ export const ecosystemLibraries: RepoTarget[] = [
   { owner: "TanStack", name: "router", category: "routing", tier: 2 },
   { owner: "molefrog", name: "wouter", category: "routing", tier: 3 },
 
-  // Meta-frameworks (5 repos)
+  // Meta-frameworks (6 repos)
   { owner: "vercel", name: "next.js", category: "framework", tier: 1 },
   { owner: "remix-run", name: "remix", category: "framework", tier: 1 },
   { owner: "expo", name: "expo", category: "framework", tier: 1 },
   { owner: "gatsbyjs", name: "gatsby", category: "framework", tier: 2 },
+  { owner: "facebook", name: "docusaurus", category: "framework", tier: 2 },
   { owner: "withastro", name: "astro", category: "framework", tier: 2 },
 
   // Forms & Validation (5 repos)

--- a/src/lib/ris/collectors/npm-collector.ts
+++ b/src/lib/ris/collectors/npm-collector.ts
@@ -200,6 +200,7 @@ export class NPMCollector {
       'remix-run/remix': '@remix-run/react',
       'molefrog/wouter': 'wouter',
       'gatsbyjs/gatsby': 'gatsby',
+      'facebook/docusaurus': '@docusaurus/core',
       'withastro/astro': 'astro',
       'expo/expo': 'expo',
       'react-hook-form/react-hook-form': 'react-hook-form',

--- a/src/lib/ris/data/probe-repos.ts
+++ b/src/lib/ris/data/probe-repos.ts
@@ -26,6 +26,7 @@ export const PROBE_REPOS: ProbeRepo[] = [
   { owner: 'vercel', repo: 'next.js', stars: 125000, category: 'framework', description: 'Next.js framework' },
   { owner: 'remix-run', repo: 'remix', stars: 29000, category: 'framework', description: 'Remix framework' },
   { owner: 'gatsbyjs', repo: 'gatsby', stars: 55000, category: 'framework', description: 'Gatsby framework' },
+  { owner: 'facebook', repo: 'docusaurus', stars: 59000, category: 'framework', description: 'Docusaurus documentation framework' },
   { owner: 'expo', repo: 'expo', stars: 32000, category: 'framework', description: 'Expo React Native' },
 
   // UI Component Libraries


### PR DESCRIPTION
## Summary
- add `facebook/docusaurus` to the tracked ecosystem/meta-framework library set
- map RIS npm collection for Docusaurus to `@docusaurus/core`
- update related ingestion, probe-repo, display-name, and contributor-count references

## Root Cause
Docusaurus had been requested for inclusion, but the tracked library registry and related RIS metadata still only covered the previous set of libraries. That meant it would not appear in the tracked ecosystem data or resolve to the intended npm package for RIS collection.

## Solution
Added Docusaurus to the tracked meta-framework libraries, wired the npm package mapping to `@docusaurus/core`, updated the ingestion/probe datasets that mirror tracked libraries, and refreshed the user-facing/library-count copy that references the tracked set.

## Test Plan
- [x] Added failing tests
- [x] Implemented fix
- [x] Verified passing targeted tests
- [x] Regression checked with full unit test project
- [x] Ran `npx eslint` on changed source files
- [x] Ran `npx tsc --noEmit`
- [ ] `npm run lint` is fully green in the repo *(currently blocked by pre-existing unrelated lint errors on `main`)*

## Screenshots
- N/A (data/config/documentation change)