### PR TITLE
Add communities link to mobile menu

### DIFF
--- a/e2e/mobile-menu.spec.ts
+++ b/e2e/mobile-menu.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test('should show Communities link in mobile sidebar navigation', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Open menu' }).click();
+
+  const communitiesLink = page.getByRole('link', { name: 'Communities' });
+  await expect(communitiesLink).toBeVisible();
+});

--- a/src/components/layout/mobile-menu.tsx
+++ b/src/components/layout/mobile-menu.tsx
@@ -57,6 +57,7 @@ export function MobileMenu({ session }: MobileMenuProps) {
         { href: "/about", label: "About" },
         { href: "/updates", label: "Updates" },
         { href: "/impact", label: "Impact" },
+        { href: "/communities", label: "Communities" },
       ];
 
   return (


### PR DESCRIPTION
## Summary

Added the communities link to the mobile menu.

---

## Root Cause (for bugs)

Missed entry in `navigationLinks` variable at `src/components/layout/mobile-menu.tsx`.

---

## Solution

Added communities entry to `navigationLinks`.

```json
{ "href": "/communities", "label": "Communities" },
```

---

## Scope

- [x] This PR has a single concern
- [ ] Refactors are directly required for this change
- [ ] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Added or updated tests for the changed behavior
- [x] Confirmed the test fails without the fix, when practical
- [x] Verified tests pass with the fix
- [x] Regression tested the original scenario
- [x] Manually verified UI behavior if applicable

Describe specific scenarios tested:

---

## Screenshots (if UI)

### Before
<img width="970" height="1046" alt="Screenshot 2026-05-05 at 20 07 54" src="https://github.com/user-attachments/assets/3e68eb74-f7b5-4f21-b9bd-2cef2b034f3b" />

### After

<img width="970" height="1046" alt="Screenshot 2026-05-05 at 19 56 00" src="https://github.com/user-attachments/assets/821118ed-7ae0-4964-b901-c18ec3ee1239" />

https://github.com/user-attachments/assets/512b623d-4f10-4fe7-8db2-dfaeb8400244

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---

## Notes for Reviewers

Anything specific you'd like feedback on.
