### PR TITLE
Fix: block merge eligibility for do-not-merge PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, labeled, unlabeled]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -11,6 +11,25 @@ on:
     #   - "src/**/*.jsx"
 
 jobs:
+  merge-eligibility:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Block merge when PR is labeled do-not-merge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = (context.payload.pull_request.labels || []).map(label => label.name)
+            const blockedLabel = 'status:do-not-merge'
+            const isBlocked = labels.includes(blockedLabel)
+
+            core.info(`labels=${labels.join(', ')}`)
+
+            if (isBlocked) {
+              core.setFailed(`PR is not eligible for merge while it has the ${blockedLabel} label.`)
+            }
+
   claude-review-skip-check:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- add a `merge-eligibility` workflow job that fails when a PR has the `status:do-not-merge` label
- rerun the workflow when labels are added or removed so merge eligibility updates immediately

## Root Cause
There was no workflow-level guard preventing a labeled `status:do-not-merge` PR from remaining merge-eligible.

## Solution
Add a dedicated `merge-eligibility` check in the PR workflow and trigger it on `labeled` / `unlabeled` events.

## Test Plan
- [x] Added workflow logic to fail when `status:do-not-merge` is present
- [x] Added label-change triggers so eligibility re-evaluates immediately
- [x] Validated workflow YAML structure locally
- [x] Included signed-off commit for DCO compliance
