### PR TITLE
Run e2e tests on ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,12 +19,13 @@ jobs:
       GITHUB_CLIENT_SECRET: ci-placeholder-secret
     services:
       redis:
-        image: redis
+        image: redis:alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 10
+          --health-start-period 1s
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -35,4 +36,4 @@ jobs:
       - name: Seed Redis
         run: npm run seed:communities
       - name: Run Playwright tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --reporter=list

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,38 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
+    env:
+      REDIS_URL: redis://redis:6379
+      NEXTAUTH_SECRET: ci-placeholder-secret
+      GITHUB_CLIENT_ID: ci-placeholder-id
+      GITHUB_CLIENT_SECRET: ci-placeholder-secret
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Seed Redis
+        run: npm run seed:communities
+      - name: Run Playwright tests
+        run: npm run test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Seed Redis
         run: npm run seed:communities
       - name: Run Playwright tests
-        run: npm run test:e2e -- --reporter=list
+        run: npm run test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  reporter: 'list',
   use: {
     baseURL: 'http://localhost:3000',
   },
@@ -9,6 +10,8 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: true,
+    stdout: 'ignore',
+    stderr: 'ignore',
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } }


### PR DESCRIPTION
## Summary

Recently added e2e tests rely solely on local execution. By adding the `e2e.yml` GitHub Actions workflow, these tests will run on CI. 

---

## Scope

- [x] This PR has a single concern
- [ ] Refactors are directly required for this change
- [ ] No unrelated formatting or cleanup is included

---

## Screenshots (if UI)

<img width="1335" height="920" alt="Screenshot 2026-05-06 at 11 17 41" src="https://github.com/user-attachments/assets/c8f6426a-4a42-471f-ab83-f739c6a0840b" />

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---

## Notes for Reviewers

* Action is using npm as a package manager. I noticed both package-lock.json and bun.lock in the repo. 
* Trigger is set on pull_request to main
