### PR TITLE
Fix pill overflow

### DIFF
--- a/e2e/pill.spec.ts
+++ b/e2e/pill.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ viewport: { width: 320, height: 844 } });
+
+test('should not overflow viewport', async ({ page }) => {
+  await page.goto('/');
+
+  const pill = page.getByText('Community-Driven · Transparent · Impactful');
+  await expect(pill).toBeInViewport({ratio: 1});
+});

--- a/src/components/ui/pill.tsx
+++ b/src/components/ui/pill.tsx
@@ -30,7 +30,7 @@ export function Pill({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-2 rounded-full border border-border bg-muted px-3 py-2 text-xs uppercase tracking-[0.15em] text-muted-foreground backdrop-blur sm:gap-3 sm:px-4 sm:tracking-[0.3em]",
+        "inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-muted px-3 py-2 text-xs uppercase tracking-[0.15em] text-muted-foreground backdrop-blur sm:gap-3 sm:px-4 sm:tracking-[0.3em]",
         className,
       )}
     >
@@ -38,7 +38,7 @@ export function Pill({
         className={cn("h-2 w-2 shrink-0 rounded-full", dotClass)}
         aria-hidden="true"
       />
-      <span className="whitespace-nowrap">{children}</span>
+      <span className="truncate">{children}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

The text _Community-Driven · Transparent · Impactful_ inside the `Pill` component was overflowing its parent and the viewport.

---

## Root Cause (for bugs)

Missing `text-overflow`.

---

## Solution

Added Tailwind's `truncate` class.

---

## Scope

- [x] This PR has a single concern
- [ ] Refactors are directly required for this change
- [ ] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Added or updated tests for the changed behavior
- [x] Confirmed the test fails without the fix, when practical
- [x] Verified tests pass with the fix
- [x] Regression tested the original scenario
- [x] Manually verified UI behavior if applicable

Describe specific scenarios tested:

---

## Screenshots (if UI)

### Before 
<img width="712" height="960" alt="Screenshot 2026-05-07 at 13 19 10" src="https://github.com/user-attachments/assets/aa980711-7f54-446b-bc7b-339b763f284d" />
### After
<img width="728" height="962" alt="Screenshot 2026-05-07 at 13 18 20" src="https://github.com/user-attachments/assets/6b6e80d7-4411-4d2f-a303-366f17527f2b" />

https://github.com/user-attachments/assets/06b6c978-f776-47ab-9a34-c19a924fb9ce


---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---

## Notes for Reviewers

Anything specific you'd like feedback on.
