### PR TITLE
Fix: add React Strict DOM to tracked ecosystem libraries (closes #62)

### DIFF
--- a/src/lib/ingest/loaders/libraries.ts
+++ b/src/lib/ingest/loaders/libraries.ts
@@ -22,9 +22,10 @@ export class LibrariesLoader implements ContentLoader {
   name = 'LibrariesLoader';
 
   private libraries: LibraryData[] = [
-    // Core React & React Native (9 repositories)
+    // Core React & React Native (10 repositories)
     { repo: 'facebook/react', name: 'React', category: 'Core React', tier: 'Tier 1' },
     { repo: 'facebook/react-native', name: 'React Native', category: 'Core React', tier: 'Tier 1' },
+    { repo: 'facebook/react-strict-dom', name: 'React Strict DOM', category: 'Core React', tier: 'Tier 2' },
     { repo: 'facebook/hermes', name: 'Hermes', category: 'Core React', tier: 'Tier 1' },
     { repo: 'reactjs/react.dev', name: 'React Documentation', category: 'Core React', tier: 'Tier 1' },
     { repo: 'reactjs/rfcs', name: 'React RFCs', category: 'Core React', tier: 'Tier 1' },

--- a/src/lib/library-icons.tsx
+++ b/src/lib/library-icons.tsx
@@ -56,6 +56,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
   // Core React
   react: SiReact,
   "react-native": SiReact,
+  "react-strict-dom": SiReact,
   jest: SiJest,
   relay: SiGraphql,
   hermes: SiReact, // Hermes is from Meta/Facebook
@@ -142,6 +143,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
 export const libraryDisplayNames: Record<string, string> = {
   react: "React",
   "react-native": "React Native",
+  "react-strict-dom": "React Strict DOM",
   jest: "Jest",
   relay: "Relay",
   hermes: "Hermes",

--- a/src/lib/maintainer-tiers.test.ts
+++ b/src/lib/maintainer-tiers.test.ts
@@ -93,4 +93,30 @@ describe('ecosystemLibraries', () => {
       })
     );
   });
+
+  it('includes React Strict DOM in related library datasets', async () => {
+    expect(findLibrary('facebook', 'react-strict-dom')).toMatchObject({
+      category: 'core',
+      tier: 2,
+    });
+    expect(NPMCollector.getPackageName('facebook', 'react-strict-dom')).toBe('react-strict-dom');
+    expect(libraryDisplayNames['react-strict-dom']).toBe('React Strict DOM');
+
+    expect(PROBE_REPOS).toContainEqual(
+      expect.objectContaining({
+        owner: 'facebook',
+        repo: 'react-strict-dom',
+        category: 'ui-library',
+      })
+    );
+
+    const loader = new LibrariesLoader();
+    const records = await loader.load();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'library-facebook-react-strict-dom',
+        title: 'React Strict DOM',
+      })
+    );
+  });
 });

--- a/src/lib/maintainer-tiers.ts
+++ b/src/lib/maintainer-tiers.ts
@@ -48,11 +48,12 @@ export type ContributionStats = {
 };
 
 export const ecosystemLibraries: RepoTarget[] = [
-  // Core React (9 repos)
+  // Core React (10 repos)
   { owner: "facebook", name: "react", category: "core", tier: 1 }, // Includes React Compiler (in /compiler subdirectory)
   { owner: "facebook", name: "relay", category: "data", tier: 1 },
   { owner: "facebook", name: "jest", category: "testing", tier: 1 },
   { owner: "facebook", name: "react-native", category: "core", tier: 1 },
+  { owner: "facebook", name: "react-strict-dom", category: "core", tier: 2 },
   { owner: "facebook", name: "hermes", category: "core", tier: 1, hasNpmPackage: false }, // JavaScript engine (C++ binary, not on NPM)
   { owner: "reactjs", name: "react.dev", category: "core", tier: 1, hasNpmPackage: false }, // Documentation website (not a library)
   { owner: "reactjs", name: "rfcs", category: "core", tier: 1, hasNpmPackage: false }, // RFC repository (not a library)

--- a/src/lib/ris/collectors/npm-collector.ts
+++ b/src/lib/ris/collectors/npm-collector.ts
@@ -172,6 +172,7 @@ export class NPMCollector {
     const specialCases: Record<string, string | null> = {
       'facebook/react': 'react',
       'facebook/react-native': 'react-native',
+      'facebook/react-strict-dom': 'react-strict-dom',
       'facebook/jest': 'jest',
       'facebook/relay': 'react-relay',
       'facebook/hermes': null, // JavaScript engine (C++ binary, not on NPM)

--- a/src/lib/ris/data/probe-repos.ts
+++ b/src/lib/ris/data/probe-repos.ts
@@ -28,6 +28,7 @@ export const PROBE_REPOS: ProbeRepo[] = [
   { owner: 'gatsbyjs', repo: 'gatsby', stars: 55000, category: 'framework', description: 'Gatsby framework' },
   { owner: 'facebook', repo: 'docusaurus', stars: 59000, category: 'framework', description: 'Docusaurus documentation framework' },
   { owner: 'expo', repo: 'expo', stars: 32000, category: 'framework', description: 'Expo React Native' },
+  { owner: 'facebook', repo: 'react-strict-dom', stars: 3506, category: 'ui-library', description: 'React Strict DOM cross-platform component system' },
 
   // UI Component Libraries
   { owner: 'mui', repo: 'material-ui', stars: 93000, category: 'ui-library', description: 'Material UI' },


### PR DESCRIPTION
## Summary
- add `facebook/react-strict-dom` to the tracked ecosystem library set as a core entry
- map the repository to the canonical npm package `react-strict-dom`
- update related display, probe, and loader datasets so React Strict DOM appears consistently

## Root Cause
- the tracked ecosystem datasets did not include React Strict DOM, so the repository, npm mapping, and derived library datasets could not recognize it

## Solution
- wrote a regression test covering the React Strict DOM repository entry, npm mapping, display name, probe repo list, and libraries loader
- added the minimal data entries required across the tracked ecosystem sources to satisfy that test

## Test Plan
- [x] Added a failing regression test for React Strict DOM dataset coverage
- [x] Verified the new test failed before implementation
- [x] Implemented the minimal fix to make the regression pass
- [x] Ran `npx vitest run src/lib/maintainer-tiers.test.ts`
- [x] Ran `npx tsc --noEmit`
- [x] Ran focused ESLint on touched files
- [ ] Ran full `npm run lint` cleanly *(blocked by pre-existing repo-wide lint errors unrelated to this change)*

## Screenshots
- N/A (data-only change)