### PR TITLE
Feat: add React Michigan community

### DIFF
--- a/src/data/communities.test.ts
+++ b/src/data/communities.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { REACT_COMMUNITIES } from './communities';
+
+describe('REACT_COMMUNITIES', () => {
+  it('includes the approved React Michigan community entry', () => {
+    expect(REACT_COMMUNITIES).toContainEqual(
+      expect.objectContaining({
+        id: 'react-michigan',
+        name: 'React Michigan',
+        slug: 'react-michigan',
+        city: 'Grand Rapids',
+        region: 'Michigan',
+        country: 'United States',
+        timezone: 'America/Detroit',
+        verified: true,
+        verification_status: 'verified',
+      })
+    );
+  });
+});

--- a/src/data/communities.ts
+++ b/src/data/communities.ts
@@ -1,6 +1,6 @@
 /**
  * React Communities - Single Source of Truth
- * 65 communities with corrected meetup URLs
+ * 66 communities with corrected meetup URLs
  * Last updated: 2025-10-24T20:22:31.823Z
  */
 
@@ -2516,6 +2516,41 @@ export const REACT_COMMUNITIES: Community[] = [
     "created_at": "2025-10-24T15:05:17.672Z",
     "updated_at": "2025-10-24T15:05:17.672Z",
     "meetup_url": "reactdenver.com"
+  },
+  {
+    "id": "react-michigan",
+    "name": "React Michigan",
+    "slug": "react-michigan",
+    "city": "Grand Rapids",
+    "region": "Michigan",
+    "country": "United States",
+    "timezone": "America/Detroit",
+    "coordinates": {
+      "lat": 42.9634,
+      "lng": -85.6681
+    },
+    "organizers": [
+      {
+        "id": "xue",
+        "name": "Xue",
+        "role": "Lead Organizer"
+      }
+    ],
+    "founded_date": "2026-05-08",
+    "event_types": [
+      "meetup"
+    ],
+    "description": "Michigan-based React community getting started in Grand Rapids, with fuller public description and links forthcoming.",
+    "member_count": 0,
+    "typical_attendance": 0,
+    "meeting_frequency": "irregular",
+    "primary_language": "English",
+    "status": "new",
+    "invite_only": false,
+    "verified": true,
+    "verification_status": "verified",
+    "created_at": "2026-05-15T20:22:40.000Z",
+    "updated_at": "2026-05-15T20:22:40.000Z"
   }
 ];
 


### PR DESCRIPTION
Refs #66

## Summary
- add React Michigan to the source community dataset
- mark it as a verified new community in Grand Rapids, Michigan
- add regression coverage asserting the entry is present

## Notes
- Kept the organizer email out of the public repo/PR content.
- Public entry includes organizer name only.
- Group URL / website can be added later when ready.

## Validation
- `npx vitest run src/data/communities.test.ts --project unit`
- `npx eslint src/data/communities.ts src/data/communities.test.ts`
- `npx tsc --noEmit`
