### PR TITLE
Fix: correct sitemap coverage for public routes (closes #70)

### DIFF
--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -69,6 +69,7 @@ describe('sitemap', () => {
         '/privacy',
         '/scoring',
         '/store',
+        '/store/collections',
         '/store/collections/foundation-drop',
         '/store/products/react-cap',
         '/terms',

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/data/communities', () => ({
+  REACT_COMMUNITIES: [
+    {
+      slug: 'react-miami',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    },
+  ],
+}));
+
+vi.mock('@/lib/authors', () => ({
+  getAllAuthors: () => [
+    {
+      slug: 'seth-webster',
+    },
+  ],
+}));
+
+vi.mock('@/lib/updates', () => ({
+  getAllUpdates: () => [
+    {
+      slug: 'spring-update',
+      metadata: {
+        date: '2026-04-20T00:00:00.000Z',
+      },
+    },
+  ],
+}));
+
+vi.mock('@/lib/shopify', () => ({
+  getAllCollections: vi.fn(async () => [
+    {
+      handle: 'foundation-drop',
+      updatedAt: '2026-04-01T00:00:00.000Z',
+    },
+  ]),
+  getAllProducts: vi.fn(async () => [
+    {
+      handle: 'react-cap',
+    },
+  ]),
+}));
+
+describe('sitemap', () => {
+  it('excludes dead educators routes and includes the missing public static and dynamic routes', async () => {
+    const { default: sitemap } = await import('./sitemap');
+
+    const entries = await sitemap();
+    const urls = entries.map((entry) => new URL(entry.url).pathname);
+
+    expect(urls).not.toContain('/educators');
+    expect(urls).not.toContain('/educators/apply');
+
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        '/',
+        '/about',
+        '/about/board-of-directors',
+        '/about/technical-steering-committee',
+        '/authors',
+        '/authors/seth-webster',
+        '/communities',
+        '/communities/add',
+        '/communities/react-miami',
+        '/communities/start',
+        '/impact',
+        '/libraries',
+        '/privacy',
+        '/scoring',
+        '/store',
+        '/store/collections/foundation-drop',
+        '/store/products/react-cap',
+        '/terms',
+        '/updates',
+        '/updates/spring-update',
+      ]),
+    );
+  });
+});

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -48,6 +48,9 @@ describe('sitemap', () => {
 
     const entries = await sitemap();
     const urls = entries.map((entry) => new URL(entry.url).pathname);
+    const collectionEntry = entries.find(
+      (entry) => new URL(entry.url).pathname === '/store/collections/foundation-drop',
+    );
 
     expect(urls).not.toContain('/educators');
     expect(urls).not.toContain('/educators/apply');
@@ -77,5 +80,7 @@ describe('sitemap', () => {
         '/updates/spring-update',
       ]),
     );
+
+    expect(collectionEntry?.lastModified).toEqual(new Date('2026-04-01T00:00:00.000Z'));
   });
 });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -39,6 +39,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     buildEntry(baseUrl, '/privacy', 'yearly', 0.4),
     buildEntry(baseUrl, '/terms', 'yearly', 0.4),
     buildEntry(baseUrl, '/store', 'daily', 0.9),
+    buildEntry(baseUrl, '/store/collections', 'weekly', 0.8),
     buildEntry(baseUrl, '/communities', 'weekly', 0.9),
     buildEntry(baseUrl, '/communities/start', 'monthly', 0.9),
     buildEntry(baseUrl, '/communities/add', 'monthly', 0.7),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -68,8 +68,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   try {
     const collections = await getAllCollections();
-    collectionRoutes = collections.map((collection) =>
-      buildEntry(baseUrl, `/store/collections/${collection.handle}`, 'weekly', 0.8),
+    collectionRoutes = collections.map((collection: { handle: string; updatedAt?: string }) =>
+      buildEntry(
+        baseUrl,
+        `/store/collections/${collection.handle}`,
+        'weekly',
+        0.8,
+        collection.updatedAt ? new Date(collection.updatedAt) : new Date(),
+      ),
     );
   } catch (error) {
     console.error('Error fetching collections for sitemap:', error);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,88 +4,91 @@
  */
 
 import { MetadataRoute } from 'next';
-import { getAllCollections } from '@/lib/shopify';
+
+import { REACT_COMMUNITIES } from '@/data/communities';
+import { getAllAuthors } from '@/lib/authors';
+import { getAllCollections, getAllProducts } from '@/lib/shopify';
+import { getAllUpdates } from '@/lib/updates';
+
+const buildEntry = (
+  baseUrl: string,
+  path: string,
+  changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'],
+  priority: number,
+  lastModified: Date = new Date(),
+): MetadataRoute.Sitemap[number] => ({
+  url: path ? `${baseUrl}${path}` : baseUrl,
+  lastModified,
+  changeFrequency,
+  priority,
+});
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://react.foundation';
 
-  // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/impact`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.9,
-    },
-    // Store
-    {
-      url: `${baseUrl}/store`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    // Communities
-    {
-      url: `${baseUrl}/communities`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/communities/start`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/communities/add`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    // Educators
-    {
-      url: `${baseUrl}/educators`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/educators/apply`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
+    buildEntry(baseUrl, '', 'daily', 1.0),
+    buildEntry(baseUrl, '/about', 'monthly', 0.8),
+    buildEntry(baseUrl, '/about/board-of-directors', 'monthly', 0.7),
+    buildEntry(baseUrl, '/about/technical-steering-committee', 'monthly', 0.7),
+    buildEntry(baseUrl, '/impact', 'weekly', 0.9),
+    buildEntry(baseUrl, '/authors', 'weekly', 0.8),
+    buildEntry(baseUrl, '/updates', 'weekly', 0.8),
+    buildEntry(baseUrl, '/libraries', 'weekly', 0.8),
+    buildEntry(baseUrl, '/scoring', 'weekly', 0.8),
+    buildEntry(baseUrl, '/privacy', 'yearly', 0.4),
+    buildEntry(baseUrl, '/terms', 'yearly', 0.4),
+    buildEntry(baseUrl, '/store', 'daily', 0.9),
+    buildEntry(baseUrl, '/communities', 'weekly', 0.9),
+    buildEntry(baseUrl, '/communities/start', 'monthly', 0.9),
+    buildEntry(baseUrl, '/communities/add', 'monthly', 0.7),
   ];
 
-  // Dynamic collection pages
+  const communityRoutes: MetadataRoute.Sitemap = REACT_COMMUNITIES.map((community) =>
+    buildEntry(
+      baseUrl,
+      `/communities/${community.slug}`,
+      'weekly',
+      0.7,
+      community.updated_at ? new Date(community.updated_at) : new Date(),
+    ),
+  );
+
+  const authorRoutes: MetadataRoute.Sitemap = getAllAuthors().map((author) =>
+    buildEntry(baseUrl, `/authors/${author.slug}`, 'monthly', 0.6),
+  );
+
+  const updateRoutes: MetadataRoute.Sitemap = getAllUpdates().map((update) =>
+    buildEntry(baseUrl, `/updates/${update.slug}`, 'monthly', 0.7, new Date(update.metadata.date)),
+  );
+
   let collectionRoutes: MetadataRoute.Sitemap = [];
+  let productRoutes: MetadataRoute.Sitemap = [];
+
   try {
     const collections = await getAllCollections();
-    collectionRoutes = collections.map((collection: { handle: string; updatedAt?: string }) => ({
-      url: `${baseUrl}/store/collections/${collection.handle}`,
-      lastModified: new Date(collection.updatedAt || Date.now()),
-      changeFrequency: 'weekly' as const,
-      priority: 0.8,
-    }));
+    collectionRoutes = collections.map((collection) =>
+      buildEntry(baseUrl, `/store/collections/${collection.handle}`, 'weekly', 0.8),
+    );
   } catch (error) {
     console.error('Error fetching collections for sitemap:', error);
   }
 
-  // Dynamic product pages would go here if we had a getProducts function
-  // For now, products are discovered via collections
+  try {
+    const products = await getAllProducts();
+    productRoutes = products.map((product) =>
+      buildEntry(baseUrl, `/store/products/${product.handle}`, 'weekly', 0.7),
+    );
+  } catch (error) {
+    console.error('Error fetching products for sitemap:', error);
+  }
 
-  return [...staticRoutes, ...collectionRoutes];
+  return [
+    ...staticRoutes,
+    ...communityRoutes,
+    ...authorRoutes,
+    ...updateRoutes,
+    ...collectionRoutes,
+    ...productRoutes,
+  ];
 }

--- a/src/lib/shopify.test.ts
+++ b/src/lib/shopify.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('getAllCollections', () => {
+  const originalEnv = {
+    SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+    SHOPIFY_STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN,
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.SHOPIFY_STORE_DOMAIN = 'react-foundation.myshopify.com';
+    process.env.SHOPIFY_STOREFRONT_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    process.env.SHOPIFY_STORE_DOMAIN = originalEnv.SHOPIFY_STORE_DOMAIN;
+    process.env.SHOPIFY_STOREFRONT_TOKEN = originalEnv.SHOPIFY_STOREFRONT_TOKEN;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns collection updatedAt values from the Shopify response for sitemap consumers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          collections: {
+            edges: [
+              {
+                node: {
+                  id: 'gid://shopify/Collection/1',
+                  handle: 'foundation-drop',
+                  title: 'Foundation Drop',
+                  description: 'A limited collection',
+                  descriptionHtml: '<p>A limited collection</p>',
+                  updatedAt: '2026-04-01T00:00:00.000Z',
+                  image: null,
+                  products: {
+                    edges: [],
+                  },
+                  isDrop: null,
+                  dropNumber: null,
+                  dropStartDate: null,
+                  dropEndDate: null,
+                  dropSeason: null,
+                  dropYear: null,
+                  dropTheme: null,
+                  limitedEditionSize: null,
+                  isPerennial: null,
+                  collectionType: null,
+                  homeFeatured: null,
+                  homeFeaturedOrder: null,
+                  accentGradient: null,
+                  timeLimited: null,
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getAllCollections } = await import('./shopify');
+    const collections = await getAllCollections();
+
+    const [{ body }] = fetchMock.mock.calls.map(([, requestInit]) => requestInit as RequestInit);
+    const requestPayload = JSON.parse(String(body)) as { query: string };
+
+    expect(requestPayload.query).toContain('updatedAt');
+    expect(collections[0]).toEqual(
+      expect.objectContaining({
+        handle: 'foundation-drop',
+        updatedAt: '2026-04-01T00:00:00.000Z',
+      }),
+    );
+  });
+});

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -439,6 +439,7 @@ export interface ShopifyCollection {
   title: string;
   description: string;
   descriptionHtml: string;
+  updatedAt: string;
   image: {
     url: string;
     altText: string | null;
@@ -529,6 +530,7 @@ export async function getAllCollections(limit = 50): Promise<ShopifyCollection[]
             title
             description
             descriptionHtml
+            updatedAt
             image {
               url
               altText


### PR DESCRIPTION
## Summary
- remove the dead `/educators` sitemap entries
- add the missing public static routes to `sitemap.xml`
- enumerate public community, author, update, collection, and product detail routes
- add a regression test covering the original bug and the expanded sitemap coverage

## Root Cause
`src/app/sitemap.ts` hardcoded a short static route list that still included unimplemented `/educators` pages and never enumerated several public routes that already exist in the app. It also omitted product detail pages entirely.

## Solution
- replace the brittle hand-maintained route list with a fuller public-route set
- derive dynamic sitemap entries from the same data sources that back the public pages
- keep Shopify-backed collections/products behind existing try/catch boundaries so the sitemap still degrades gracefully if Shopify is unavailable
- lock the behavior in with a focused unit regression test

## Test Plan
- [x] Added a failing regression test for `sitemap()` before implementation
- [x] Implemented the smallest fix to make the regression pass
- [x] `PATH="$HOME/.asdf/shims:$PATH" pnpm exec vitest run src/app/sitemap.test.ts --project unit`
- [x] `PATH="$HOME/.asdf/shims:$PATH" pnpm exec vitest run --project unit`
- [x] `PATH="$HOME/.asdf/shims:$PATH" npx tsc --noEmit`
- [x] Regression scenario verified: `/educators*` excluded and missing public routes included
- [ ] `npm run lint`

## Notes
- `npm run lint` still fails on pre-existing repo-wide issues unrelated to this change (77 existing lint errors across scripts, admin pages, stories, and other untouched files).
- No UI screenshots needed because this only changes generated sitemap output.
