### PR TITLE
fix: adjust stat-card for small layouts

### DIFF
--- a/e2e/community-page.spec.ts
+++ b/e2e/community-page.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+import { REACT_COMMUNITIES } from '@/data/communities';
+
+test.describe('Community page', () => {
+  const community = REACT_COMMUNITIES.at(0) ?? { slug: 'react-prague', meeting_frequency: 'irregular' };
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/communities/${community.slug}`);
+  });
+
+  test('renders community stats with compact variant size', async ({ page }) => {
+    const statBox = page.getByText(community.meeting_frequency, { exact: true });
+
+    await expect(statBox).toBeVisible();
+    await expect(statBox).toHaveClass('font-bold mb-1 text-2xl text-foreground');
+  });
+});

--- a/src/app/communities/[slug]/page.tsx
+++ b/src/app/communities/[slug]/page.tsx
@@ -385,6 +385,7 @@ function StatBox({
       color="primary"
       variant="outlined"
       className={`text-center ${capitalize ? 'capitalize' : ''}`}
+      size="compact"
     />
   );
 }

--- a/src/components/rfds/stat-card.tsx
+++ b/src/components/rfds/stat-card.tsx
@@ -25,6 +25,8 @@ export interface StatCardProps {
   variant?: 'default' | 'outlined' | 'elevated';
   /** Color scheme */
   color?: 'primary' | 'success' | 'destructive' | 'warning';
+  /** Size of the card elements */
+  size?: 'default' | 'compact';
   /** Custom className */
   className?: string;
 }
@@ -38,6 +40,7 @@ export function StatCard({
   highlight = false,
   variant = 'outlined',
   color = 'primary',
+  size = 'default',
   className,
 }: StatCardProps) {
   const trendIcons = {
@@ -66,6 +69,11 @@ export function StatCard({
     warning: highlight ? 'text-warning-foreground' : 'text-foreground',
   };
 
+  const valueFontSize = {
+    default: 'text-2xl md:text-3xl',
+    compact: 'text-2xl'
+  }
+
   return (
     <SemanticCard
       variant={variant}
@@ -84,7 +92,8 @@ export function StatCard({
             </div>
           )}
           <div className={cn(
-            'text-2xl md:text-3xl font-bold mb-1',
+            'font-bold mb-1',
+            valueFontSize[size],
             valueColorClasses[color]
           )}>
             {value}


### PR DESCRIPTION
## Summary

Adjusts StatCard to make it usable in compact situations.

Community page stats UI is slightly broken due to the stats-card value text size. The fix might be insufficient in the future; the icon probably needs to change size as well, but for the current fix, it looks fine.

---

## Scope

- [x] This PR has a single concern
- [ ] Refactors are directly required for this change
- [x] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Added or updated tests for the changed behavior
- [ ] Confirmed the test fails without the fix, when practical
- [ ] Verified tests pass with the fix
- [ ] Regression tested the original scenario
- [x] Manually verified UI behavior if applicable

Describe specific scenarios tested:

---

## Screenshots (if UI)

Before:
<img width="1314" height="402" alt="image" src="https://github.com/user-attachments/assets/e6a0a37b-fcd5-42f6-8ea3-ee1de2b2c148" />

After:
<img width="1230" height="402" alt="image" src="https://github.com/user-attachments/assets/57e68ede-03a6-4658-b673-bb6dd22bb3c1" />

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---
