### PR TITLE
Fix ContributorCard layout so description spans full card width

### DIFF
--- a/e2e/about-contributor-cards.spec.ts
+++ b/e2e/about-contributor-cards.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const CONTRIBUTOR_CARD_TITLES = [
+  "Contribute to Repos",
+  "Support Financially",
+  "Sponsor a Library",
+  "Become a Member",
+] as const;
+
+const readContributorCardLayout = (cardElement: HTMLElement) => {
+  const description = cardElement.querySelector("p.text-sm.leading-relaxed");
+  if (!description) {
+    return null;
+  }
+
+  const contentStack = description.parentElement;
+  const headerRow = description.previousElementSibling;
+  const icon = headerRow?.firstElementChild;
+  const titleContainer = headerRow?.lastElementChild;
+
+  if (!contentStack || !headerRow || !icon) {
+    return null;
+  }
+
+  const descriptionRect = description.getBoundingClientRect();
+  const iconRect = icon.getBoundingClientRect();
+  const headerRect = headerRow.getBoundingClientRect();
+
+  return {
+    contentStackUsesColumnLayout: contentStack.classList.contains("flex-col"),
+    descriptionIsSiblingOfHeaderRow:
+      headerRow.nextElementSibling === description,
+    descriptionNotNestedInHeaderRow: !headerRow.contains(description),
+    titleContainerHasNoDescription: titleContainer?.querySelector("p") === null,
+    descriptionAlignedWithCardContent:
+      Math.abs(descriptionRect.left - iconRect.left) < 2,
+    descriptionBelowHeaderRow: descriptionRect.top >= headerRect.bottom - 2,
+  };
+};
+
+test.describe("About page contributor cards", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/about");
+    await expect(
+      page.getByRole("heading", { name: "Become a Contributor" }),
+    ).toBeVisible();
+  });
+
+  test("keeps card descriptions below the icon/title row instead of beside the icon", async ({
+    page,
+  }) => {
+    const card = page.locator("#contribute .grid > div").filter({
+      has: page.getByRole("heading", {
+        name: CONTRIBUTOR_CARD_TITLES[0],
+        level: 3,
+      }),
+    });
+
+    await expect(card).toBeVisible();
+
+    const layout = await card.evaluate(readContributorCardLayout);
+
+    expect(layout).not.toBeNull();
+    expect(layout?.contentStackUsesColumnLayout).toBeTruthy();
+    expect(layout?.descriptionIsSiblingOfHeaderRow).toBeTruthy();
+    expect(layout?.descriptionNotNestedInHeaderRow).toBeTruthy();
+    expect(layout?.titleContainerHasNoDescription).toBeTruthy();
+    expect(layout?.descriptionAlignedWithCardContent).toBeTruthy();
+    expect(layout?.descriptionBelowHeaderRow).toBeTruthy();
+  });
+
+  test("renders full-width descriptions for every contributor card on desktop", async ({
+    page,
+  }) => {
+    const section = page.locator("#contribute");
+    const cards = section.locator(".grid > div");
+    await expect(cards).toHaveCount(CONTRIBUTOR_CARD_TITLES.length);
+
+    const cardCount = await cards.count();
+
+    for (let index = 0; index < cardCount; index += 1) {
+      const layout = await cards.nth(index).evaluate(readContributorCardLayout);
+      expect(layout).not.toBeNull();
+      expect(layout?.descriptionNotNestedInHeaderRow).toBeTruthy();
+
+      const widths = await cards.nth(index).evaluate((cardElement) => {
+        const description = cardElement.querySelector(
+          "p.text-sm.leading-relaxed",
+        );
+        if (!description) {
+          return null;
+        }
+
+        const cardRect = cardElement.getBoundingClientRect();
+        const descriptionRect = description.getBoundingClientRect();
+
+        return {
+          cardWidth: cardRect.width,
+          descriptionWidth: descriptionRect.width,
+        };
+      });
+
+      expect(widths).not.toBeNull();
+      expect(widths?.descriptionWidth).toBeGreaterThan(
+        (widths?.cardWidth ?? 0) * 0.75,
+      );
+    }
+  });
+});

--- a/src/components/rfds/semantic-components.tsx
+++ b/src/components/rfds/semantic-components.tsx
@@ -371,16 +371,17 @@ export function ContributorCard({
       )}
       {...props}
     >
-      <div className="flex items-start gap-4">
-        {icon}
-        <div className="flex-1">
-          <h3 className="text-xl font-semibold text-foreground">
-            {title}
-          </h3>
-          <p className="mt-2 text-sm leading-relaxed text-foreground/70">
-            {description}
-          </p>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-4">
+          {icon}
+          <div className="flex-1">
+            <h3 className="text-xl font-semibold text-foreground">{title}</h3>
+          </div>
         </div>
+
+        <p className="mt-2 text-sm leading-relaxed text-foreground/70">
+          {description}
+        </p>
       </div>
       <div className="flex flex-wrap gap-3 pt-2">
         {actions}


### PR DESCRIPTION
## Summary

Restructure the card header so the icon and title sit in one row and the description sits below at full width, improving readability on the About page contribution cards.

---

## Linked Issue or Exception

Closes #81 

---

## Root Cause (for bugs)

The icon, title, and description were placed in a single horizontal row. On desktop, the description was squeezed beside the icon, making the copy hard to read.

---

## Solution

Restructure the card header so the icon and title sit in one row and the description sits below at full width, improving readability on the About page contribution cards.

---

## Scope

- [x] This PR has a single concern
- [ ] Refactors are directly required for this change
- [x] No unrelated formatting or cleanup is included

---

## Test Plan

- [ ] Added or updated tests for the changed behavior
- [ ] Confirmed the test fails without the fix, when practical
- [ ] Verified tests pass with the fix
- [ ] Regression tested the original scenario
- [x] Manually verified UI behavior if applicable

Describe specific scenarios tested:

---

## Screenshots (if UI)

Before:
<img width="306" height="329" alt="Image" src="https://github.com/user-attachments/assets/ddd5ef44-f87b-4590-a824-4e82674060c7" />

After:
<img width="313" height="263" alt="Image" src="https://github.com/user-attachments/assets/a16801cd-9ebf-42c7-a4e3-710e5a6b85ab" />

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [x] CI passing

---