### PR TITLE
Fix: add Base UI to supported ecosystem (closes #90)

### DIFF
--- a/e2e/public-content-integrity.spec.ts
+++ b/e2e/public-content-integrity.spec.ts
@@ -19,7 +19,7 @@ const editorialRoutes = [
   {
     path: '/libraries',
     heading: 'Ecosystem support',
-    expected: '61 tracked repositories',
+    expected: '62 tracked repositories',
   },
   {
     path: '/scoring',
@@ -87,7 +87,7 @@ test('impact restores methodology and routes into library detail', async ({ page
 test('libraries and scoring publish the tracked ecosystem without stale counts', async ({ page }) => {
   await page.goto('/libraries');
 
-  await expect(page.getByText('61 tracked repositories', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('62 tracked repositories', { exact: true }).first()).toBeVisible();
   await expect(page.getByText('Core React · 7 libraries')).toBeVisible();
   await expect(page.getByText('Styling · 5 libraries')).toBeVisible();
   await expect(page.getByRole('link', { name: /React Router/i })).toBeVisible();

--- a/src/lib/ingest/loaders/libraries.ts
+++ b/src/lib/ingest/loaders/libraries.ts
@@ -76,11 +76,12 @@ export class LibrariesLoader implements ContentLoader {
     { repo: 'microsoft/playwright', name: 'Playwright', category: 'Testing', tier: 'Tier 1' },
     { repo: 'testing-library/react-hooks-testing-library', name: 'React Hooks Testing Library', category: 'Testing', tier: 'Tier 2' },
 
-    // UI/Component Libraries (7 repositories)
+    // UI/Component Libraries (8 repositories)
     { repo: 'radix-ui/primitives', name: 'Radix UI', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'ant-design/ant-design', name: 'Ant Design', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'tailwindlabs/headlessui', name: 'Headless UI', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'mui/material-ui', name: 'Material-UI', category: 'UI Libraries', tier: 'Tier 1' },
+    { repo: 'mui/base-ui', name: 'Base UI', category: 'UI Libraries', tier: 'Tier 2' },
     { repo: 'adobe/react-spectrum', name: 'React Spectrum', category: 'UI Libraries', tier: 'Tier 2' },
     { repo: 'ariakit/ariakit', name: 'Ariakit', category: 'UI Libraries', tier: 'Tier 2' },
     { repo: 'chakra-ui/chakra-ui', name: 'Chakra UI', category: 'UI Libraries', tier: 'Tier 2' },

--- a/src/lib/library-icons.tsx
+++ b/src/lib/library-icons.tsx
@@ -113,6 +113,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
   "react-spectrum": null,
   ariakit: null,
   "material-ui": SiMui,
+  "base-ui": SiMui,
   "chakra-ui": SiChakraui,
   "ant-design": SiAntdesign,
 
@@ -186,6 +187,7 @@ export const libraryDisplayNames: Record<string, string> = {
   "react-spectrum": "React Spectrum",
   ariakit: "Ariakit",
   "material-ui": "Material UI",
+  "base-ui": "Base UI",
   "chakra-ui": "Chakra UI",
   "ant-design": "Ant Design",
   motion: "Framer Motion",

--- a/src/lib/maintainer-tiers.test.ts
+++ b/src/lib/maintainer-tiers.test.ts
@@ -106,6 +106,24 @@ describe('ecosystemLibraries', () => {
     );
   });
 
+  it('includes Base UI in related library datasets', async () => {
+    expect(findLibrary('mui', 'base-ui')).toMatchObject({
+      category: 'ui',
+      tier: 2,
+    });
+    expect(NPMCollector.getPackageName('mui', 'base-ui')).toBe('@base-ui/react');
+    expect(libraryDisplayNames['base-ui']).toBe('Base UI');
+
+    const loader = new LibrariesLoader();
+    const records = await loader.load();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'library-mui-base-ui',
+        title: 'Base UI',
+      })
+    );
+  });
+
   it('includes React Strict DOM in related library datasets', async () => {
     expect(findLibrary('facebook', 'react-strict-dom')).toMatchObject({
       category: 'core',

--- a/src/lib/maintainer-tiers.ts
+++ b/src/lib/maintainer-tiers.ts
@@ -102,12 +102,13 @@ export const ecosystemLibraries: RepoTarget[] = [
   { owner: "microsoft", name: "playwright", category: "testing", tier: 1 },
   { owner: "testing-library", name: "react-hooks-testing-library", category: "testing", tier: 2 },
 
-  // UI/Component Libraries (7 repos)
+  // UI/Component Libraries (8 repos)
   { owner: "radix-ui", name: "primitives", category: "ui", tier: 1 },
   { owner: "tailwindlabs", name: "headlessui", category: "ui", tier: 1 },
   { owner: "adobe", name: "react-spectrum", category: "ui", tier: 2 },
   { owner: "ariakit", name: "ariakit", category: "ui", tier: 2 },
   { owner: "mui", name: "material-ui", category: "ui", tier: 1 },
+  { owner: "mui", name: "base-ui", category: "ui", tier: 2 },
   { owner: "chakra-ui", name: "chakra-ui", category: "ui", tier: 2 },
   { owner: "ant-design", name: "ant-design", category: "ui", tier: 1 },
 

--- a/src/lib/ris/collectors/npm-collector.ts
+++ b/src/lib/ris/collectors/npm-collector.ts
@@ -219,6 +219,7 @@ export class NPMCollector {
       'adobe/react-spectrum': '@adobe/react-spectrum',
       'ariakit/ariakit': '@ariakit/react',
       'mui/material-ui': '@mui/material',
+      'mui/base-ui': '@base-ui/react',
       'chakra-ui/chakra-ui': '@chakra-ui/react',
       'ant-design/ant-design': 'antd',
       'framer/motion': 'framer-motion',


### PR DESCRIPTION
## Summary
- add `mui/base-ui` as a Tier 2 supported ecosystem entry
- map Base UI to its current npm package, `@base-ui/react`
- add the display/icon and chatbot loader records used by the ecosystem UI and ingestion flow
- cover the registry wiring and public tracked-repository count with regression tests

## Why
Base UI meets the tracked-library criteria and was only implied under the broader MUI umbrella. Its repository, package, display metadata, and ingestion record should be represented explicitly.

## Scope
This branch is rebuilt on current `main` after #104. It intentionally does not add Base UI to `PROBE_REPOS`, because that list is the fixed consumer sample used to measure import adoption rather than a mirror of tracked libraries.

## Test Plan
- [x] Confirmed the focused Base UI regression failed before implementation
- [x] `npx vitest run src/lib/maintainer-tiers.test.ts --project unit`
- [x] `npx vitest run --project unit`
- [x] `npx tsc --noEmit`
- [x] Focused ESLint on all touched source files
- [x] `npm run build`
- [x] `npx playwright test e2e/public-content-integrity.spec.ts --project=chromium` (19 passed)

Closes #90