### PR TITLE
Fix: add React Native Testing Library to supported ecosystem (closes #92)

### DIFF
--- a/e2e/public-content-integrity.spec.ts
+++ b/e2e/public-content-integrity.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
 
+import { ecosystemLibraries } from '../src/lib/maintainer-tiers';
+
+const trackedRepositoryLabel = `${ecosystemLibraries.length} tracked repositories`;
+
 const editorialRoutes = [
   {
     path: '/about/board-of-directors',
@@ -19,7 +23,7 @@ const editorialRoutes = [
   {
     path: '/libraries',
     heading: 'Ecosystem support',
-    expected: '63 tracked repositories',
+    expected: trackedRepositoryLabel,
   },
   {
     path: '/scoring',
@@ -87,7 +91,7 @@ test('impact restores methodology and routes into library detail', async ({ page
 test('libraries and scoring publish the tracked ecosystem without stale counts', async ({ page }) => {
   await page.goto('/libraries');
 
-  await expect(page.getByText('63 tracked repositories', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(trackedRepositoryLabel, { exact: true }).first()).toBeVisible();
   await expect(page.getByText('Core React · 7 libraries')).toBeVisible();
   await expect(page.getByText('Styling · 5 libraries')).toBeVisible();
   await expect(page.getByRole('link', { name: /React Router/i })).toBeVisible();

--- a/src/lib/ingest/loaders/libraries.ts
+++ b/src/lib/ingest/loaders/libraries.ts
@@ -70,11 +70,12 @@ export class LibrariesLoader implements ContentLoader {
     { repo: 'jquense/yup', name: 'Yup', category: 'Forms & Validation', tier: 'Tier 2' },
     { repo: 'final-form/react-final-form', name: 'React Final Form', category: 'Forms & Validation', tier: 'Tier 3' },
 
-    // Testing (4 repositories)
+    // Testing (5 repositories)
     { repo: 'testing-library/react-testing-library', name: 'React Testing Library', category: 'Testing', tier: 'Tier 1' },
     { repo: 'vitest-dev/vitest', name: 'Vitest', category: 'Testing', tier: 'Tier 1' },
     { repo: 'microsoft/playwright', name: 'Playwright', category: 'Testing', tier: 'Tier 1' },
     { repo: 'testing-library/react-hooks-testing-library', name: 'React Hooks Testing Library', category: 'Testing', tier: 'Tier 2' },
+    { repo: 'callstack/react-native-testing-library', name: 'React Native Testing Library', category: 'Testing', tier: 'Tier 2' },
 
     // UI/Component Libraries (8 repositories)
     { repo: 'radix-ui/primitives', name: 'Radix UI', category: 'UI Libraries', tier: 'Tier 1' },

--- a/src/lib/library-icons.tsx
+++ b/src/lib/library-icons.tsx
@@ -106,6 +106,7 @@ export const libraryIcons: Record<string, IconComponent | null> = {
   vitest: SiVitest,
   playwright: null, // No Simple Icon available
   "react-hooks-testing-library": null,
+  "react-native-testing-library": null,
 
   // UI/Component Libraries
   primitives: SiRadixui, // Radix UI Primitives
@@ -183,6 +184,7 @@ export const libraryDisplayNames: Record<string, string> = {
   vitest: "Vitest",
   playwright: "Playwright",
   "react-hooks-testing-library": "React Hooks Testing Library",
+  "react-native-testing-library": "React Native Testing Library",
   primitives: "Radix UI",
   headlessui: "Headless UI",
   "react-spectrum": "React Spectrum",

--- a/src/lib/maintainer-tiers.test.ts
+++ b/src/lib/maintainer-tiers.test.ts
@@ -167,4 +167,24 @@ describe('ecosystemLibraries', () => {
       })
     );
   });
+
+  it('includes React Native Testing Library in related library datasets', async () => {
+    expect(findLibrary('callstack', 'react-native-testing-library')).toMatchObject({
+      category: 'testing',
+      tier: 2,
+    });
+    expect(NPMCollector.getPackageName('callstack', 'react-native-testing-library')).toBe(
+      '@testing-library/react-native'
+    );
+    expect(libraryDisplayNames['react-native-testing-library']).toBe('React Native Testing Library');
+
+    const loader = new LibrariesLoader();
+    const records = await loader.load();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        id: 'library-callstack-react-native-testing-library',
+        title: 'React Native Testing Library',
+      })
+    );
+  });
 });

--- a/src/lib/maintainer-tiers.ts
+++ b/src/lib/maintainer-tiers.ts
@@ -96,11 +96,12 @@ export const ecosystemLibraries: RepoTarget[] = [
   { owner: "jquense", name: "yup", category: "forms", tier: 2 },
   { owner: "final-form", name: "react-final-form", category: "forms", tier: 3 },
 
-  // Testing (4 repos)
+  // Testing (5 repos)
   { owner: "testing-library", name: "react-testing-library", category: "testing", tier: 1 },
   { owner: "vitest-dev", name: "vitest", category: "testing", tier: 1 },
   { owner: "microsoft", name: "playwright", category: "testing", tier: 1 },
   { owner: "testing-library", name: "react-hooks-testing-library", category: "testing", tier: 2 },
+  { owner: "callstack", name: "react-native-testing-library", category: "testing", tier: 2 },
 
   // UI/Component Libraries (8 repos)
   { owner: "radix-ui", name: "primitives", category: "ui", tier: 1 },

--- a/src/lib/ris/collectors/npm-collector.ts
+++ b/src/lib/ris/collectors/npm-collector.ts
@@ -213,6 +213,7 @@ export class NPMCollector {
       'final-form/react-final-form': 'react-final-form',
       'testing-library/react-testing-library': '@testing-library/react',
       'testing-library/react-hooks-testing-library': '@testing-library/react-hooks',
+      'callstack/react-native-testing-library': '@testing-library/react-native',
       'vitest-dev/vitest': 'vitest',
       'microsoft/playwright': '@playwright/test',
       'radix-ui/primitives': '@radix-ui/react-primitive',


### PR DESCRIPTION
## Summary
- add `callstack/react-native-testing-library` to the tracked ecosystem library list
- add the canonical npm mapping for `@testing-library/react-native`
- mirror the entry into the ingest/display datasets used by the supported ecosystem surface
- make the public content integrity count assertion derive from the tracked library registry instead of a stale hardcoded total

## Root Cause
React Native Testing Library was missing from the repo’s tracked ecosystem datasets, so it could not appear in the supported ecosystem surface or related ingestion flows. The branch also needed to drop the earlier `PROBE_REPOS` addition and refresh one browser assertion after the post-rewrite ecosystem count changed.

## Solution
Added the library as a tier-2 testing entry in the canonical tracked-library list, updated the npm/package, ingest-loader, and display-name datasets that still need to stay in sync, and refreshed the public content integrity assertion so it follows `ecosystemLibraries.length` instead of a stale literal count.

## Test Plan
- [x] Added focused regression coverage first in `src/lib/maintainer-tiers.test.ts`
- [x] Verified the new test failed on `main` before implementation
- [x] Implemented the minimal dataset updates needed for the new entry
- [x] Verified the focused regression test passes after the fix
- [x] Ran `pnpm exec vitest run src/lib/maintainer-tiers.test.ts --project unit`
- [x] Ran `pnpm exec vitest run --project unit`
- [x] Ran `npx tsc --noEmit`
- [x] Re-checked the original regression path for the new library entry

Closes #92
