### PR TITLE
Fix: add robots metadata route (closes #94)

### DIFF
--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+describe('robots metadata route', () => {
+  it('returns a crawl policy plus sitemap for the public site', async () => {
+    const { default: robots } = await import('./robots');
+
+    expect(robots()).toEqual({
+      rules: {
+        userAgent: '*',
+        allow: '/',
+      },
+      sitemap: 'https://react.foundation/sitemap.xml',
+      host: 'https://react.foundation',
+    });
+  });
+});

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -8,6 +8,7 @@ describe('robots metadata route', () => {
       rules: {
         userAgent: '*',
         allow: '/',
+        disallow: ['/admin', '/api', '/auth', '/profile', '/sticky-test', '/theme-test'],
       },
       sitemap: 'https://react.foundation/sitemap.xml',
       host: 'https://react.foundation',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+const siteUrl = 'https://react.foundation';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,11 +2,14 @@ import { MetadataRoute } from 'next';
 
 const siteUrl = 'https://react.foundation';
 
+const disallowRules = ['/admin', '/api', '/auth', '/profile', '/sticky-test', '/theme-test'];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
+      disallow: disallowRules,
     },
     sitemap: `${siteUrl}/sitemap.xml`,
     host: siteUrl,


### PR DESCRIPTION
## Summary
- add a dedicated Next metadata route for `robots.txt`
- return an explicit crawl policy for the public site
- add a focused regression test covering the route output

## Root Cause
The app had no `robots.txt` metadata route or static file, so requests to `/robots.txt` fell through to the 404 page.

## Solution
Add `src/app/robots.ts` as the canonical metadata route and cover it with a focused Vitest regression test.

## Test Plan
- [x] wrote a failing regression test first (`src/app/robots.test.ts`)
- [x] verified the new test failed on the pre-fix branch because `./robots` did not exist
- [x] implemented the smallest fix to make the test pass
- [x] re-ran focused app tests: `npx vitest run src/app/globals.test.ts src/app/sitemap.test.ts src/app/robots.test.ts --reporter=verbose`
- [x] ran typecheck: `npx tsc --noEmit`
- [x] ran focused lint: `npx eslint src/app/robots.ts src/app/robots.test.ts`

Closes #94
