### PR TITLE
Claude/react foundation homepage redesign

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -97,21 +97,21 @@ export default function AboutPage() {
           {/* Mission */}
           <section className="scroll-mt-32">
             <div className="text-center">
-              <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground">
                 Our Mission
               </h2>
-              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
+              <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
                 The React Foundation exists to ensure the React ecosystem thrives
                 for generations to come. We provide direct financial support to
                 maintainers, fund educational initiatives, and ensure
                 accessibility for developers worldwide.
               </p>
             </div>
-            <div className="mt-12 grid gap-6 sm:grid-cols-3">
+            <div className="mt-14 grid gap-4 sm:grid-cols-3">
               {MISSION.map((item) => (
                 <div
                   key={item.title}
-                  className="rounded-3xl border border-border/60 bg-card p-6"
+                  className="flex flex-col gap-6 rounded-3xl border border-border/60 bg-card p-6 sm:min-h-[200px] sm:justify-between sm:gap-0"
                 >
                   <svg
                     className={`h-6 w-6 ${item.accent}`}
@@ -123,12 +123,14 @@ export default function AboutPage() {
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" d={item.icon} />
                   </svg>
-                  <h3 className="mt-5 text-base font-semibold text-foreground">
-                    {item.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                    {item.description}
-                  </p>
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-base leading-relaxed text-muted-foreground">
+                      {item.description}
+                    </p>
+                  </div>
                 </div>
               ))}
             </div>
@@ -136,20 +138,26 @@ export default function AboutPage() {
 
           {/* How it works */}
           <section className="scroll-mt-32">
-            <h2 className="text-center text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-foreground">
               How it works
             </h2>
-            <ol className="mt-12 divide-y divide-border/60">
+            <ol className="mt-14 sm:pr-16">
               {STEPS.map((step, i) => (
-                <li key={step.title} className="flex gap-6 py-6 first:pt-0">
-                  <span className="pt-0.5 font-mono text-sm text-muted-foreground">
-                    {i + 1}
-                  </span>
-                  <div>
-                    <h3 className="text-lg font-semibold text-foreground">
+                <li key={step.title} className="flex gap-5 sm:gap-6">
+                  {/* Marker + connector */}
+                  <div className="flex flex-col items-center self-stretch">
+                    <span className="flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card text-base font-semibold text-muted-foreground">
+                      {i + 1}
+                    </span>
+                    {i < STEPS.length - 1 && (
+                      <span aria-hidden className="w-px flex-1 bg-border" />
+                    )}
+                  </div>
+                  <div className="pb-10 pt-1.5">
+                    <h3 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
                       {step.title}
                     </h3>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    <p className="mt-2 text-base leading-relaxed text-muted-foreground">
                       {step.description}
                     </p>
                   </div>
@@ -176,7 +184,7 @@ export default function AboutPage() {
                   href={body.href}
                   className="group rounded-3xl border border-border/60 bg-card p-8 transition-colors hover:border-primary/40"
                 >
-                  <p className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+                  <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     {body.eyebrow}
                   </p>
                   <h3 className="mt-3 text-lg font-semibold text-foreground">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,330 +1,214 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ButtonLink } from "@/components/ui/button";
-import { Pill } from "@/components/ui/pill";
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
 import { Footer } from "@/components/layout/footer";
 import { BecomeContributor } from "@/components/home/become-contributor";
-import { EcosystemLibraries } from "@/components/home/ecosystem-libraries";
-import { FoundingMembers } from "@/components/home/founding-members";
 import { ExecutiveMessage } from "@/components/home/executive-message";
-import { RFDS } from "@/components/rfds";
-
-const sections = [
-  { id: 'executive-message', title: 'Executive Message', level: 1 as const },
-  { id: 'mission', title: 'Our Mission', level: 1 as const },
-  { id: 'how-it-works', title: 'How It Works', level: 1 as const },
-  { id: 'founding-members', title: 'Founding Members', level: 1 as const },
-  { id: 'supported-ecosystem', title: 'Supported Ecosystem', level: 1 as const },
-  { id: 'governance', title: 'Transparent Governance', level: 1 as const },
-  { id: 'become-contributor', title: 'Become a Contributor', level: 1 as const },
-];
 
 export const metadata: Metadata = {
   title: "About | React Foundation",
-  description: "Learn about the React Foundation's mission, governance, and how we support the ecosystem.",
+  description:
+    "Learn about the React Foundation's mission, governance, and how we support the ecosystem.",
 };
+
+const MISSION = [
+  {
+    title: "Sustainable Funding",
+    description:
+      "Creating reliable revenue streams that support open source maintainers.",
+    accent: "text-success",
+    icon: "M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+  },
+  {
+    title: "Full Transparency",
+    description: "Quarterly reports showing exactly how funds are distributed.",
+    accent: "text-primary",
+    icon: "M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z",
+  },
+  {
+    title: "Community First",
+    description: "Decisions driven by community needs and maintainer feedback.",
+    accent: "text-destructive",
+    icon: "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.3-3.9A7.9 7.9 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z",
+  },
+];
+
+const STEPS = [
+  {
+    title: "Contribute to the Ecosystem",
+    description:
+      "Submit code, documentation, RFCs, and bug reports to React and 54+ ecosystem libraries. Your contributions directly improve the tools millions of developers use every day.",
+  },
+  {
+    title: "Join the Community",
+    description:
+      "Organize meetups, create educational content, teach workshops, or help other developers learn React. Community organizers and educators are essential to ecosystem growth.",
+  },
+  {
+    title: "Support Through the Store",
+    description:
+      "One way to fund the ecosystem is through our official merchandise store. 100% of profits support maintainers, educators, and community organizers based on transparent impact metrics.",
+  },
+  {
+    title: "Transparent Impact",
+    description:
+      "Quarterly impact reports detail exactly how funds support maintainers, education, and accessibility initiatives. Full transparency in how contributions make a difference.",
+  },
+];
+
+const GOVERNANCE = [
+  {
+    href: "/about/board-of-directors",
+    title: "Board of Directors",
+    eyebrow: "Strategic Leadership · Financial Oversight · Governance",
+    description:
+      "Our Board provides strategic guidance, ensures financial oversight, and maintains the foundation's commitment to transparency and community-first values.",
+  },
+  {
+    href: "/about/technical-steering-committee",
+    title: "Technical Steering Committee",
+    eyebrow: "Technical Excellence · Innovation · Open Standards",
+    description:
+      "The TSC drives technical excellence across the React ecosystem, establishing standards, best practices, and supporting innovation in libraries and tools.",
+  },
+];
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen bg-background pt-24 text-muted-foreground">
-      <div className="absolute inset-x-0 top-[-6rem] -z-10 flex justify-center blur-3xl">
-        <div className="h-[24rem] w-[60rem] bg-gradient-to-r from-success/50 via-primary/60 to-primary/70 opacity-30" />
-      </div>
+    <div className="relative bg-background pt-24">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[420px] bg-gradient-to-b from-muted/70 to-background" />
 
-      <div className="mx-auto flex max-w-6xl flex-col px-6 pb-24 sm:px-8 lg:px-12">
-        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
-          <main className="flex flex-col gap-20">
+      <div className="animate-page-appear mx-auto max-w-4xl px-6 pb-24 sm:px-8 lg:px-12">
+        <main className="flex flex-col gap-24">
           {/* Hero */}
-          <section className="space-y-8 pt-12">
-            <Pill>Our Story · Our Mission · Our Values</Pill>
-            <div>
-              <h1 className="text-5xl font-semibold leading-tight text-foreground sm:text-6xl">
-                About React Foundation
-              </h1>
-              <p className="mt-8 max-w-2xl text-lg text-foreground/70">
-                We&apos;re building a sustainable future for the React ecosystem through
-                community funding, transparent governance, and unwavering support for
-                the maintainers who make it all possible.
+          <section className="pt-10 text-center sm:pt-14">
+            <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+              About The React Foundation
+            </h1>
+            <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              We&apos;re building a sustainable future for the React ecosystem
+              through community funding, transparent governance, and unwavering
+              support for the maintainers who make it all possible.
+            </p>
+          </section>
+
+          <ExecutiveMessage />
+
+          {/* Mission */}
+          <section className="scroll-mt-32">
+            <div className="text-center">
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                Our Mission
+              </h2>
+              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
+                The React Foundation exists to ensure the React ecosystem thrives
+                for generations to come. We provide direct financial support to
+                maintainers, fund educational initiatives, and ensure
+                accessibility for developers worldwide.
               </p>
+            </div>
+            <div className="mt-12 grid gap-6 sm:grid-cols-3">
+              {MISSION.map((item) => (
+                <div
+                  key={item.title}
+                  className="rounded-3xl border border-border/60 bg-card p-6"
+                >
+                  <svg
+                    className={`h-6 w-6 ${item.accent}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.75}
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d={item.icon} />
+                  </svg>
+                  <h3 className="mt-5 text-base font-semibold text-foreground">
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
             </div>
           </section>
 
-          {/* Executive Message */}
-          <div id="executive-message">
-            <ExecutiveMessage />
-          </div>
-
-          {/* Mission */}
-          <div id="mission">
-          <ScrollReveal animation="fade-up">
-            <section className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-muted/60 p-12">
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-                Our Mission
-              </h2>
-              <p className="max-w-3xl text-lg leading-relaxed text-foreground/70">
-                The React Foundation exists to ensure the React ecosystem thrives for
-                generations to come. We provide direct financial support to maintainers,
-                fund educational initiatives, and ensure accessibility for developers
-                worldwide.
-              </p>
-              <div className="space-y-4 pt-4">
-                <div className="flex gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-success/10">
-                    <div className="h-2 w-2 rounded-full bg-success/50" />
-                  </div>
+          {/* How it works */}
+          <section className="scroll-mt-32">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              How it works
+            </h2>
+            <ol className="mt-12 divide-y divide-border/60">
+              {STEPS.map((step, i) => (
+                <li key={step.title} className="flex gap-6 py-6 first:pt-0">
+                  <span className="pt-0.5 font-mono text-sm text-muted-foreground">
+                    {i + 1}
+                  </span>
                   <div>
-                    <h3 className="font-semibold text-foreground">Sustainable Funding</h3>
-                    <p className="mt-1 text-sm text-foreground/60">
-                      Creating reliable revenue streams that support open source maintainers
+                    <h3 className="text-lg font-semibold text-foreground">
+                      {step.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      {step.description}
                     </p>
                   </div>
-                </div>
-                <div className="flex gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
-                    <div className="h-2 w-2 rounded-full bg-primary/50" />
-                  </div>
-                  <div>
-                    <h3 className="font-semibold text-foreground">Full Transparency</h3>
-                    <p className="mt-1 text-sm text-foreground/60">
-                      Quarterly reports showing exactly how funds are distributed
-                    </p>
-                  </div>
-                </div>
-                <div className="flex gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent/10">
-                    <div className="h-2 w-2 rounded-full bg-accent/50" />
-                  </div>
-                  <div>
-                    <h3 className="font-semibold text-foreground">Community First</h3>
-                    <p className="mt-1 text-sm text-foreground/60">
-                      Decisions driven by community needs and maintainer feedback
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </section>
-          </ScrollReveal>
-          </div>
+                </li>
+              ))}
+            </ol>
+          </section>
 
-          {/* How It Works */}
-          <div id="how-it-works">
-          <ScrollReveal animation="scale">
-            <section className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-muted/60 p-12">
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-                How It Works
-              </h2>
-              <div className="grid gap-6 lg:grid-cols-2">
-                <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-primary/80">
-                    <span className="text-xl font-bold text-primary-foreground">1</span>
-                  </div>
-                  <h3 className="text-xl font-semibold text-foreground">
-                    Contribute to the Ecosystem
-                  </h3>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    Submit code, documentation, RFCs, and bug reports to React and 54+
-                    ecosystem libraries. Your contributions directly improve the tools
-                    millions of developers use every day.
-                  </p>
-                </div>
-
-                <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-success to-primary">
-                    <span className="text-xl font-bold text-success-foreground">2</span>
-                  </div>
-                  <h3 className="text-xl font-semibold text-foreground">
-                    Join the Community
-                  </h3>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    Organize meetups, create educational content, teach workshops, or
-                    help other developers learn React. Community organizers and educators
-                    are essential to ecosystem growth.
-                  </p>
-                </div>
-
-                <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-accent to-accent/80">
-                    <span className="text-xl font-bold text-white">3</span>
-                  </div>
-                  <h3 className="text-xl font-semibold text-foreground">
-                    Support Through the Store
-                  </h3>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    One way to fund the ecosystem is through our official merchandise store.
-                    100% of profits support maintainers, educators, and community organizers
-                    based on transparent impact metrics.
-                  </p>
-                </div>
-
-                <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 to-accent">
-                    <span className="text-xl font-bold text-primary-foreground">4</span>
-                  </div>
-                  <h3 className="text-xl font-semibold text-foreground">
-                    Transparent Impact
-                  </h3>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    Quarterly impact reports detail exactly how funds support maintainers,
-                    education, and accessibility initiatives. Full transparency in how
-                    contributions make a difference.
-                  </p>
-                </div>
-              </div>
-            </section>
-          </ScrollReveal>
-          </div>
-
-          {/* Founding Members */}
-          <div id="founding-members">
-            <FoundingMembers />
-          </div>
-
-          {/* Ecosystem Libraries */}
-          <div id="supported-ecosystem">
-            <EcosystemLibraries
-              title="Supported Ecosystem"
-              showMissingLibraryIssue
-            />
-          </div>
-
-          {/* Governance / Communities */}
-          <div id="governance">
-          <ScrollReveal animation="fade-up">
-            <section
-              className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-muted/60 p-12"
-            >
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+          {/* Governance */}
+          <section className="scroll-mt-32">
+            <div className="text-center">
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
                 Transparent Governance
               </h2>
-              <p className="max-w-3xl text-lg leading-relaxed text-foreground/70">
-                The React Foundation operates with complete transparency. All funding
-                decisions, impact reports, and financial details are published quarterly
-                for community review and feedback.
+              <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
+                All funding decisions, impact reports, and financial details are
+                published quarterly for community review and feedback.
               </p>
-
-              {/* Governance Bodies */}
-              <div className="grid gap-6 pt-6 lg:grid-cols-2">
+            </div>
+            <div className="mt-12 grid gap-6 sm:grid-cols-2">
+              {GOVERNANCE.map((body) => (
                 <Link
-                  href="/about/board-of-directors"
-                  className="group block space-y-4 rounded-2xl border border-border/10 bg-card text-card-foreground p-8 transition-all hover:border-primary/20 hover:bg-gradient-to-br hover:from-primary/5 hover:to-accent/5 hover:shadow-lg"
+                  key={body.href}
+                  href={body.href}
+                  className="group rounded-3xl border border-border/60 bg-card p-8 transition-colors hover:border-primary/40"
                 >
-                  <div className="flex items-center gap-4">
-                    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-primary/80 shadow-lg">
-                      <svg className="h-7 w-7 text-primary-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-                      </svg>
-                    </div>
-                    <div className="flex-1">
-                      <h3 className="text-xl font-semibold text-foreground transition-colors group-hover:text-primary">
-                        Board of Directors
-                      </h3>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        Strategic Leadership · Financial Oversight · Governance
-                      </p>
-                    </div>
-                    <svg className="h-5 w-5 shrink-0 text-muted-foreground transition-all group-hover:translate-x-1 group-hover:text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </div>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    Our Board provides strategic guidance, ensures financial oversight, and
-                    maintains the foundation&apos;s commitment to transparency and community-first values.
+                  <p className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+                    {body.eyebrow}
                   </p>
+                  <h3 className="mt-3 text-lg font-semibold text-foreground">
+                    {body.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                    {body.description}
+                  </p>
+                  <span className="mt-6 inline-block text-sm font-medium text-primary transition-colors group-hover:text-primary/80">
+                    Learn more →
+                  </span>
                 </Link>
+              ))}
+            </div>
+          </section>
 
-                <Link
-                  href="/about/technical-steering-committee"
-                  className="group block space-y-4 rounded-2xl border border-border/10 bg-card text-card-foreground p-8 transition-all hover:border-success/20 hover:bg-gradient-to-br hover:from-success/5 hover:to-primary/5 hover:shadow-lg"
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-success to-primary shadow-lg">
-                      <svg className="h-7 w-7 text-success-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                      </svg>
-                    </div>
-                    <div className="flex-1">
-                      <h3 className="text-xl font-semibold text-foreground transition-colors group-hover:text-success">
-                        Technical Steering Committee
-                      </h3>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        Technical Excellence · Innovation · Open Standards
-                      </p>
-                    </div>
-                    <svg className="h-5 w-5 shrink-0 text-muted-foreground transition-all group-hover:translate-x-1 group-hover:text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </div>
-                  <p className="text-sm leading-relaxed text-foreground/70">
-                    The TSC drives technical excellence across the React ecosystem, establishing
-                    standards, best practices, and supporting innovation in libraries and tools.
-                  </p>
-                </Link>
-              </div>
-
-              {/* Governance Principles */}
-              <div className="grid gap-6 pt-6 sm:grid-cols-2">
-                <div className="space-y-3 rounded-2xl border border-border/10 bg-background/[0.03] p-6">
-                  <h3 className="font-semibold text-foreground">Open Financials</h3>
-                  <p className="text-sm text-foreground/70">
-                    Every dollar tracked and reported publicly
-                  </p>
-                </div>
-                <div className="space-y-3 rounded-2xl border border-border/10 bg-background/[0.03] p-6">
-                  <h3 className="font-semibold text-foreground">Community Input</h3>
-                  <p className="text-sm text-foreground/70">
-                    Major decisions informed by maintainer feedback
-                  </p>
-                </div>
-                <div className="space-y-3 rounded-2xl border border-border/10 bg-background/[0.03] p-6">
-                  <h3 className="font-semibold text-foreground">Quarterly Reports</h3>
-                  <p className="text-sm text-foreground/70">
-                    Detailed impact metrics published every quarter
-                  </p>
-                </div>
-                <div className="space-y-3 rounded-2xl border border-border/10 bg-background/[0.03] p-6">
-                  <h3 className="font-semibold text-foreground">Open Source Values</h3>
-                  <p className="text-sm text-foreground/70">
-                    Built on the same principles as the ecosystem we support
-                  </p>
-                </div>
-              </div>
-            </section>
-          </ScrollReveal>
-          </div>
-
-          {/* Become a Contributor */}
-          <div id="become-contributor">
-          <ScrollReveal animation="scale">
-            <BecomeContributor />
-          </ScrollReveal>
-          </div>
+          <BecomeContributor />
 
           {/* CTA */}
-          <ScrollReveal animation="fade-up">
-            <section className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-gradient-to-br from-primary/10 via-warning/10 to-warning/5 p-12 text-center">
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-                Ready to Make an Impact?
-              </h2>
-              <p className="mx-auto max-w-2xl text-lg text-foreground/70">
-                Start supporting the React ecosystem today. Every contribution helps build
-                a sustainable future for open source.
-              </p>
-              <div className="flex flex-wrap items-center justify-center gap-4">
-                <ButtonLink href="/store" variant="primary" size="lg">
-                  Shop the Store
-                </ButtonLink>
-                <ButtonLink href="/impact" variant="secondary" size="lg">
-                  View Our Impact
-                </ButtonLink>
-              </div>
-            </section>
-          </ScrollReveal>
+          <section className="flex flex-col items-center gap-6 py-4 text-center">
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              Ready to Make an Impact?
+            </h2>
+            <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
+              Start supporting the React ecosystem today. Every contribution helps
+              build a sustainable future for open source.
+            </p>
+            <ButtonLink href="/become-a-member" variant="primary" size="lg">
+              Get involved
+            </ButtonLink>
+          </section>
         </main>
-
-        {/* Table of Contents Sidebar */}
-        <RFDS.TableOfContents sections={sections} />
-        </div>
       </div>
 
       <Footer />

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -4,176 +4,147 @@
  */
 
 import { Suspense } from 'react';
+import Link from 'next/link';
 import { CommunityMap } from '@/components/communities/CommunityMap';
 import { CommunityFilters } from '@/components/communities/CommunityFilters';
 import { CommunityList } from '@/components/communities/CommunityList';
 import { CommunityStats } from '@/components/communities/CommunityStats';
-import { CommunitySortDropdown } from '@/components/communities/CommunitySortDropdown';
-import { AddCommunityCTA } from '@/components/communities/AddCommunityCTA';
+import { Footer } from '@/components/layout/footer';
 import './leaflet.css';
 
 export const metadata = {
   title: 'Find a React Community | React Foundation',
-  description: 'Discover React meetups, conferences, and communities near you. Connect with React developers worldwide.',
+  description:
+    'Discover React meetups, conferences, and communities near you. Connect with React developers worldwide.',
 };
+
+// CoIS tiers as categorical brand indicators (mapped to semantic tokens).
+const TIERS: { label: string; dot: string }[] = [
+  { label: 'Platinum', dot: 'bg-primary' },
+  { label: 'Gold', dot: 'bg-warning' },
+  { label: 'Silver', dot: 'bg-muted-foreground' },
+  { label: 'Bronze', dot: 'bg-destructive' },
+];
 
 export default function CommunitiesPage() {
   return (
-    <div className="min-h-screen bg-background pt-16">
-      {/* Hero Section */}
-      <section className="bg-gradient-to-b from-primary/10 via-primary/5 to-background py-20 border-b border-border">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <h1 className="text-5xl md:text-6xl font-bold text-foreground mb-6">
-              Find Your React Community
-            </h1>
-            <p className="text-xl text-muted-foreground mb-10 leading-relaxed">
-              Connect with React developers through meetups, conferences, and
-              study groups around the world.
-            </p>
+    <div className="relative min-h-screen bg-background pt-24">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[440px] bg-gradient-to-b from-muted/70 to-background" />
 
-            <div className="flex flex-wrap gap-4 justify-center">
-              <a
-                href="#communities"
-                className="inline-block bg-primary text-primary-foreground px-8 py-4 rounded-lg font-semibold hover:bg-primary/90 transition text-lg"
-              >
-                🗺️ Explore Communities
-              </a>
-              <a
-                href="/communities/start"
-                className="inline-block bg-secondary text-secondary-foreground px-8 py-4 rounded-lg font-semibold hover:bg-secondary/90 transition text-lg"
-              >
-                🚀 Start a Community
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
+      <div className="mx-auto max-w-6xl px-6 pb-24 sm:px-8 lg:px-12">
+        {/* Hero */}
+        <section className="pt-10 text-center sm:pt-14">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Find Your React Community
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Connect with React developers through meetups, conferences, and study
+            groups around the world.
+          </p>
+        </section>
 
-      {/* Stats Bar - Dynamic from Redis */}
-      <section className="bg-card border-b border-border py-12">
-        <div className="container mx-auto px-6">
+        {/* Stats */}
+        <section className="mt-14">
           <Suspense fallback={<StatsSkeleton />}>
             <CommunityStats />
           </Suspense>
-        </div>
-      </section>
+        </section>
 
-      {/* Map Section */}
-      <section id="map" className="bg-muted/30 border-b border-border py-12">
-        <div className="container mx-auto px-6">
-          <div className="mb-8 text-center">
-            <h2 className="text-3xl font-bold text-foreground mb-3">
-              Communities Worldwide
-            </h2>
-            <p className="text-muted-foreground">
-              Click any marker to learn more about a community
-            </p>
-          </div>
-
-          <div className="bg-card rounded-xl border border-border overflow-hidden shadow-lg">
+        {/* Map */}
+        <section id="map" className="mt-12">
+          <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-card shadow-sm">
             <Suspense fallback={<MapSkeleton />}>
               <CommunityMap />
             </Suspense>
+
+            {/* Tier legend */}
+            <div className="absolute right-4 top-4 z-[1000] rounded-xl border border-border/60 bg-background/90 p-3 backdrop-blur">
+              <p className="mb-2 text-xs font-semibold text-foreground">CoIS Tier</p>
+              <ul className="space-y-1.5">
+                {TIERS.map((tier) => (
+                  <li
+                    key={tier.label}
+                    className="flex items-center gap-2 text-xs text-muted-foreground"
+                  >
+                    <span className={`h-2 w-2 rounded-full ${tier.dot}`} />
+                    {tier.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* All communities */}
+        <section id="communities" className="mt-16">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+              All communities
+            </h2>
+            <Link
+              href="/communities/start"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              Start a community
+            </Link>
           </div>
 
-          {/* Add Community CTA */}
-          <AddCommunityCTA />
-        </div>
-      </section>
-
-      {/* Main Content: Filters + List */}
-      <section id="communities" className="py-12">
-        <div className="container mx-auto px-6">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-            {/* Filters Sidebar */}
-            <aside className="lg:col-span-1">
-              <div className="sticky top-24">
-                <Suspense fallback={<FiltersSkeleton />}>
-                  <CommunityFilters />
-                </Suspense>
-              </div>
-            </aside>
-
-            {/* Community List */}
-            <main className="lg:col-span-3">
-              <div className="mb-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                <h2 className="text-2xl md:text-3xl font-bold text-foreground">
-                  All Communities
-                </h2>
-                <CommunitySortDropdown />
-              </div>
-
-              <Suspense fallback={<ListSkeleton />}>
-                <CommunityList />
-              </Suspense>
-            </main>
+          <div className="mt-8">
+            <Suspense fallback={<FiltersSkeleton />}>
+              <CommunityFilters />
+            </Suspense>
           </div>
-        </div>
-      </section>
 
-      {/* CTA Section */}
-      <section className="bg-gradient-to-b from-primary/5 to-primary/10 border-t border-border py-20">
-        <div className="container mx-auto px-6 text-center">
-          <h2 className="text-4xl font-bold text-foreground mb-4">
-            Don't See a Community Near You?
-          </h2>
-          <p className="text-lg text-muted-foreground mb-10 max-w-2xl mx-auto">
-            Starting a React community is easier than you think. We provide
-            resources, templates, and support to help you succeed.
-          </p>
-          <a
-            href="/communities/start"
-            className="inline-block bg-primary text-primary-foreground px-8 py-4 rounded-lg font-semibold hover:bg-primary/90 transition text-lg"
-          >
-            Start Your Own Community
-          </a>
-        </div>
-      </section>
+          <div className="mt-8">
+            <Suspense fallback={<ListSkeleton />}>
+              <CommunityList />
+            </Suspense>
+          </div>
+        </section>
+      </div>
+
+      <Footer />
     </div>
   );
 }
 
 function StatsSkeleton() {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center max-w-5xl mx-auto">
-      {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="space-y-2">
-          <div className="h-12 bg-muted animate-pulse rounded" />
-          <div className="h-4 bg-muted animate-pulse rounded w-24 mx-auto" />
+    <div className="flex flex-wrap items-start justify-center gap-x-16 gap-y-8">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="space-y-2 text-center">
+          <div className="mx-auto h-10 w-20 animate-pulse rounded bg-muted" />
+          <div className="mx-auto h-4 w-24 animate-pulse rounded bg-muted" />
         </div>
       ))}
     </div>
   );
 }
 
-function FiltersSkeleton() {
+function MapSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="h-10 bg-muted animate-pulse rounded" />
-      <div className="h-32 bg-muted animate-pulse rounded" />
-      <div className="h-32 bg-muted animate-pulse rounded" />
-      <div className="h-32 bg-muted animate-pulse rounded" />
+    <div className="flex h-[520px] items-center justify-center bg-muted">
+      <p className="text-sm text-muted-foreground">Loading map…</p>
     </div>
   );
 }
 
-function MapSkeleton() {
+function FiltersSkeleton() {
   return (
-    <div className="h-[600px] bg-muted animate-pulse flex items-center justify-center">
-      <div className="text-center">
-        <div className="text-4xl mb-4">🗺️</div>
-        <p className="text-muted-foreground">Loading map...</p>
-      </div>
+    <div className="flex flex-col gap-4 sm:flex-row">
+      <div className="h-10 flex-1 animate-pulse rounded-lg bg-muted" />
+      <div className="h-10 animate-pulse rounded-lg bg-muted sm:w-40" />
+      <div className="h-10 animate-pulse rounded-lg bg-muted sm:w-44" />
+      <div className="h-10 animate-pulse rounded-lg bg-muted sm:w-40" />
     </div>
   );
 }
 
 function ListSkeleton() {
   return (
-    <div className="space-y-6">
-      {[1, 2, 3, 4, 5].map((i) => (
-        <div key={i} className="h-48 bg-muted animate-pulse rounded-xl" />
+    <div className="space-y-4">
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="h-40 animate-pulse rounded-2xl bg-muted" />
       ))}
     </div>
   );

--- a/src/app/communities/page.tsx
+++ b/src/app/communities/page.tsx
@@ -18,14 +18,6 @@ export const metadata = {
     'Discover React meetups, conferences, and communities near you. Connect with React developers worldwide.',
 };
 
-// CoIS tiers as categorical brand indicators (mapped to semantic tokens).
-const TIERS: { label: string; dot: string }[] = [
-  { label: 'Platinum', dot: 'bg-primary' },
-  { label: 'Gold', dot: 'bg-warning' },
-  { label: 'Silver', dot: 'bg-muted-foreground' },
-  { label: 'Bronze', dot: 'bg-destructive' },
-];
-
 export default function CommunitiesPage() {
   return (
     <div className="relative min-h-screen bg-background pt-24">
@@ -56,22 +48,6 @@ export default function CommunitiesPage() {
             <Suspense fallback={<MapSkeleton />}>
               <CommunityMap />
             </Suspense>
-
-            {/* Tier legend */}
-            <div className="absolute right-4 top-4 z-[1000] rounded-xl border border-border/60 bg-background/90 p-3 backdrop-blur">
-              <p className="mb-2 text-xs font-semibold text-foreground">CoIS Tier</p>
-              <ul className="space-y-1.5">
-                {TIERS.map((tier) => (
-                  <li
-                    key={tier.label}
-                    className="flex items-center gap-2 text-xs text-muted-foreground"
-                  >
-                    <span className={`h-2 w-2 rounded-full ${tier.dot}`} />
-                    {tier.label}
-                  </li>
-                ))}
-              </ul>
-            </div>
           </div>
         </section>
 
@@ -123,7 +99,7 @@ function StatsSkeleton() {
 
 function MapSkeleton() {
   return (
-    <div className="flex h-[520px] items-center justify-center bg-muted">
+    <div className="flex h-[420px] items-center justify-center bg-muted sm:h-[600px]">
       <p className="text-sm text-muted-foreground">Loading map…</p>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -93,6 +93,7 @@ html {
   --destructive-foreground: 0 0% 100%;
   --success: 142 71% 45%;           /* #10b981 emerald-500 */
   --success-foreground: 0 0% 100%;
+  --warning: 32 94% 44%;            /* #d97706 amber-600 - readable accent on light */
   --border: 214 32% 91%;            /* #e2e8f0 slate-200 */
   --input: 214 32% 91%;             /* #e2e8f0 */
   --ring: 199 89% 48%;              /* #0ea5e9 */
@@ -124,6 +125,7 @@ html {
   --destructive-foreground: 0 0% 100%;
   --success: 142 71% 45%;           /* #10b981 emerald-500 */
   --success-foreground: 0 0% 100%;
+  --warning: 36 96% 55%;            /* brighter amber for dark surfaces */
   --border: 215 25% 27%;            /* #334155 slate-700 - subtle border */
   --input: 215 25% 27%;
   --ring: 199 89% 48%;
@@ -156,6 +158,7 @@ html {
   --color-destructive-foreground: hsl(var(--destructive-foreground));
   --color-success: hsl(var(--success));
   --color-success-foreground: hsl(var(--success-foreground));
+  --color-warning: hsl(var(--warning));
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,45 @@
 import type { Metadata } from "next";
 import { Footer } from "@/components/layout/footer";
 import { FoundationHero } from "@/components/home/foundation-hero";
+import { CommunityGallery } from "@/components/home/community-gallery";
+import { MembersStrip } from "@/components/home/members-strip";
 import { MissionStatement } from "@/components/home/mission-statement";
 import { ThreePillars } from "@/components/home/three-pillars";
 import { BecomeContributor } from "@/components/home/become-contributor";
 import { JoinMovementCTA } from "@/components/home/join-movement-cta";
-import { FoundingMembers } from "@/components/home/founding-members";
 
 export const metadata: Metadata = {
   title: "React Foundation",
-  description: "Supporting the React ecosystem through community funding and governance.",
+  description:
+    "Supporting the React ecosystem through community funding and governance.",
 };
 
 export default function FoundationHome() {
   return (
-    <div className="bg-background pt-24 text-muted-foreground">
-      {/* Background gradient */}
-      <div className="absolute inset-x-0 top-[-6rem] -z-10 flex justify-center overflow-hidden blur-3xl">
-        <div className="h-[24rem] w-full max-w-[60rem] bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 opacity-30" />
-      </div>
+    <div className="relative bg-background pt-24">
+      {/* Subtle neutral backdrop behind the header + hero */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[600px] bg-gradient-to-b from-muted/70 to-background" />
 
-      <div className="animate-page-appear mx-auto flex max-w-6xl flex-col px-6 pb-24 sm:px-8 lg:px-12">
-        <main className="flex flex-col gap-20">
+      <div className="animate-page-appear mx-auto max-w-6xl px-6 pb-24 sm:px-8 lg:px-12">
+        <main>
           <FoundationHero />
-          <MissionStatement />
-          <ThreePillars />
-          <BecomeContributor />
-          <FoundingMembers />
-          <JoinMovementCTA />
+
+          <div className="mt-14 sm:mt-16">
+            <CommunityGallery />
+          </div>
+
+          <div className="mt-16">
+            <MembersStrip />
+          </div>
+
+          <div className="mt-16 border-t border-border/60" />
+
+          <div className="mt-20 flex flex-col gap-24">
+            <MissionStatement />
+            <ThreePillars />
+            <BecomeContributor />
+            <JoinMovementCTA />
+          </div>
         </main>
       </div>
 

--- a/src/app/updates/[slug]/page.tsx
+++ b/src/app/updates/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Pill } from "@/components/ui/pill";
 import { getUpdateBySlug, getAllUpdates } from "@/lib/updates";
 import { getAuthorBySlug } from "@/lib/authors";
 import { MDXRemote } from "next-mdx-remote/rsc";
@@ -49,31 +48,41 @@ export default async function UpdatePage({ params }: UpdatePageProps) {
   const author = getAuthorBySlug(update.metadata.author);
 
   return (
-    <article className="pt-12">
+    <article className="mx-auto max-w-3xl pt-6">
+      <Link
+        href="/updates"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        ← Back to news
+      </Link>
+
       {/* Post Header */}
-      <header className="space-y-6 pb-12">
-        <Pill>
-          Update ·{" "}
+      <header className="mt-8 space-y-6 border-b border-border/60 pb-10">
+        <time
+          dateTime={update.metadata.date}
+          className="block text-sm font-medium text-muted-foreground"
+        >
           {new Date(update.metadata.date).toLocaleDateString("en-US", {
             year: "numeric",
             month: "long",
             day: "numeric",
+            timeZone: "UTC",
           })}
-        </Pill>
-        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+        </time>
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
           {update.metadata.title}
         </h1>
 
         {/* Author Info */}
         {author && (
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3">
             {author.avatar && (
-              <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full border-2 border-border/20">
+              <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-full border border-border">
                 <Image
                   src={author.avatar}
                   alt={author.name}
-                  width={48}
-                  height={48}
+                  width={44}
+                  height={44}
                   className="object-cover"
                 />
               </div>
@@ -81,26 +90,26 @@ export default async function UpdatePage({ params }: UpdatePageProps) {
             <div>
               <Link
                 href={`/authors/${author.slug}`}
-                className="font-semibold text-foreground hover:text-cyan-300"
+                className="text-sm font-semibold text-foreground transition-colors hover:text-primary"
               >
                 {author.name}
               </Link>
-              <p className="text-sm text-foreground/60">{author.title}</p>
+              <p className="text-sm text-muted-foreground">{author.title}</p>
             </div>
           </div>
         )}
       </header>
 
       {/* MDX Content with prose */}
-      <div className="prose prose-lg prose-invert prose-cyan max-w-none">
+      <div className="prose prose-lg mt-10 max-w-none">
         <MDXRemote source={update.content} />
       </div>
 
       {/* Back Link */}
-      <div className="mt-12 border-t border-border/10 pt-8">
+      <div className="mt-14 border-t border-border/60 pt-8">
         <Link
           href="/updates"
-          className="text-sm text-cyan-400 transition hover:text-cyan-300"
+          className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
         >
           ← Back to all updates
         </Link>

--- a/src/app/updates/layout.tsx
+++ b/src/app/updates/layout.tsx
@@ -6,10 +6,8 @@ export default function UpdatesLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-background pt-24 text-muted-foreground">
-      <div className="absolute inset-x-0 top-[-6rem] -z-10 flex justify-center blur-3xl">
-        <div className="h-[24rem] w-[60rem] bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600 opacity-30" />
-      </div>
+    <div className="relative min-h-screen bg-background pt-24">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[360px] bg-gradient-to-b from-muted/70 to-background" />
 
       <div className="mx-auto flex max-w-4xl flex-col px-6 pb-24 sm:px-8 lg:px-12">
         {children}

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -60,14 +60,14 @@ export default function UpdatesPage() {
           No updates published yet. Check back soon.
         </p>
       ) : (
-        <section className="mt-12 space-y-6">
+        <section className="mt-12 space-y-5">
           {updates.map((update) => {
             const author = getAuthorBySlug(update.metadata.author);
             return (
               <Link
                 key={update.slug}
                 href={`/updates/${update.slug}`}
-                className="block rounded-3xl border border-border/60 bg-card p-8 transition-colors hover:border-border"
+                className="group block rounded-[2.5rem] border border-border/60 bg-card p-8 transition-colors hover:border-border sm:p-10"
               >
                 <time
                   dateTime={update.metadata.date}
@@ -77,22 +77,23 @@ export default function UpdatesPage() {
                     year: "numeric",
                     month: "long",
                     day: "numeric",
+                    timeZone: "UTC",
                   })}
                 </time>
-                <h2 className="mt-3 text-xl font-semibold text-foreground sm:text-2xl">
+                <h2 className="mt-4 text-2xl font-semibold tracking-tight text-foreground transition-colors group-hover:text-primary">
                   {update.metadata.title}
                 </h2>
-                <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
                   {update.metadata.description}
                 </p>
-                <div className="mt-6 flex items-center gap-3">
+                <div className="mt-6 flex items-center gap-2.5">
                   {author?.avatar ? (
-                    <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full border border-border">
+                    <div className="relative h-6 w-6 shrink-0 overflow-hidden rounded-full border border-border">
                       <Image
                         src={author.avatar}
                         alt={author.name}
                         fill
-                        sizes="32px"
+                        sizes="24px"
                         className="object-cover"
                       />
                     </div>
@@ -104,18 +105,16 @@ export default function UpdatesPage() {
               </Link>
             );
           })}
+
+          {/* Archive */}
+          <Link
+            href="/authors"
+            className="block rounded-[2.5rem] p-8 text-sm font-medium text-primary transition-colors hover:text-primary/80 sm:px-10"
+          >
+            View Archive →
+          </Link>
         </section>
       )}
-
-      {/* Archive */}
-      <div className="mt-10">
-        <Link
-          href="/authors"
-          className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
-        >
-          View Archive →
-        </Link>
-      </div>
     </main>
   );
 }

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Pill } from "@/components/ui/pill";
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
+import Image from "next/image";
 import { getAllUpdates } from "@/lib/updates";
 import { getAuthorBySlug } from "@/lib/authors";
 
@@ -12,58 +11,111 @@ export const metadata: Metadata = {
 
 export default function UpdatesPage() {
   const updates = getAllUpdates();
+
   return (
-    <main className="flex flex-col gap-20">
-      {/* Hero */}
-      <section className="space-y-8 pt-12">
-        <Pill>Latest News · Announcements · Community Updates</Pill>
-        <div>
-          <h1 className="text-5xl font-semibold leading-tight text-foreground sm:text-6xl">
-            Updates
-          </h1>
-          <p className="mt-8 max-w-2xl text-lg text-foreground/70">
-            Stay informed about the latest news, announcements, and initiatives from
-            the React Foundation.
-          </p>
+    <main className="pt-10 sm:pt-14">
+      {/* Header */}
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Latest news
+        </h1>
+        <div className="flex items-center gap-3">
+          <a
+            href="https://x.com/reactjs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+            </svg>
+            Follow
+          </a>
+          <a
+            href="mailto:hello@react.foundation?subject=Subscribe%20to%20React%20Foundation%20updates"
+            className="inline-flex items-center gap-2 rounded-full bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.75}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+            Subscribe
+          </a>
         </div>
-      </section>
+      </div>
 
-      {/* Updates List */}
-      <ScrollReveal animation="fade-up">
-        <section className="space-y-8">
-          {updates.map((update, idx) => {
+      {/* News list */}
+      {updates.length === 0 ? (
+        <p className="mt-12 text-sm text-muted-foreground">
+          No updates published yet. Check back soon.
+        </p>
+      ) : (
+        <section className="mt-12 space-y-6">
+          {updates.map((update) => {
             const author = getAuthorBySlug(update.metadata.author);
-
             return (
-              <ScrollReveal key={update.slug} animation="fade-up" delay={idx * 100}>
-                <Link
-                  href={`/updates/${update.slug}`}
-                  className="block rounded-3xl border border-border/10 bg-muted/60 p-8 transition hover:border-border/20 hover:bg-muted/80"
+              <Link
+                key={update.slug}
+                href={`/updates/${update.slug}`}
+                className="block rounded-3xl border border-border/60 bg-card p-8 transition-colors hover:border-border"
+              >
+                <time
+                  dateTime={update.metadata.date}
+                  className="text-sm text-muted-foreground"
                 >
-                  <div className="flex items-center gap-4 text-xs text-foreground/50">
-                    <time dateTime={update.metadata.date}>
-                      {new Date(update.metadata.date).toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
-                    </time>
-                    <span>·</span>
-                    <span>{author?.name || update.metadata.author}</span>
-                  </div>
-                  <h2 className="mt-4 text-2xl font-semibold text-foreground sm:text-3xl">
-                    {update.metadata.title}
-                  </h2>
-                  <p className="mt-4 text-base text-foreground/70">{update.metadata.description}</p>
-                  <div className="mt-6 text-sm text-cyan-400 transition hover:text-cyan-300">
-                    Read more →
-                  </div>
-                </Link>
-              </ScrollReveal>
+                  {new Date(update.metadata.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+                <h2 className="mt-3 text-xl font-semibold text-foreground sm:text-2xl">
+                  {update.metadata.title}
+                </h2>
+                <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+                  {update.metadata.description}
+                </p>
+                <div className="mt-6 flex items-center gap-3">
+                  {author?.avatar ? (
+                    <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full border border-border">
+                      <Image
+                        src={author.avatar}
+                        alt={author.name}
+                        fill
+                        sizes="32px"
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : null}
+                  <span className="text-sm font-medium text-foreground">
+                    {author?.name || update.metadata.author}
+                  </span>
+                </div>
+              </Link>
             );
           })}
         </section>
-      </ScrollReveal>
+      )}
+
+      {/* Archive */}
+      <div className="mt-10">
+        <Link
+          href="/authors"
+          className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          View Archive →
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/components/communities/CommunityFilters.tsx
+++ b/src/components/communities/CommunityFilters.tsx
@@ -1,6 +1,7 @@
 /**
  * Community Filters Component
- * Filter communities by location, type, status, etc.
+ * Filter communities by search, status, event type, and tier.
+ * Presented as a horizontal filter bar; state is synced to the URL query string.
  */
 
 'use client';
@@ -9,7 +10,11 @@ import { useEffect, useRef, useState, type RefObject } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { RFDS } from '@/components/rfds';
 import { SortDropdown } from '@/components/ui/sort-dropdown';
-import type { CommunityFilters as Filters, CommunityStatusFilter, EventType } from '@/types/community';
+import type {
+  CommunityFilters as Filters,
+  CommunityStatusFilter,
+  EventType,
+} from '@/types/community';
 
 const STATUS_OPTIONS: Array<{ value: CommunityStatusFilter; label: string }> = [
   { value: 'all', label: 'All' },
@@ -19,7 +24,27 @@ const STATUS_OPTIONS: Array<{ value: CommunityStatusFilter; label: string }> = [
   { value: 'inactive', label: 'Inactive' },
 ];
 
-function useClearDebounceOnUnmount(timer: RefObject<ReturnType<typeof setTimeout> | null>) {
+const EVENT_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'All types' },
+  { value: 'meetup', label: 'Meetup' },
+  { value: 'conference', label: 'Conference' },
+  { value: 'workshop', label: 'Workshop' },
+  { value: 'hackathon', label: 'Hackathon' },
+  { value: 'study-group', label: 'Study group' },
+  { value: 'virtual', label: 'Virtual' },
+];
+
+const TIER_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'All tiers' },
+  { value: 'platinum', label: 'Platinum' },
+  { value: 'gold', label: 'Gold' },
+  { value: 'silver', label: 'Silver' },
+  { value: 'bronze', label: 'Bronze' },
+];
+
+function useClearDebounceOnUnmount(
+  timer: RefObject<ReturnType<typeof setTimeout> | null>,
+) {
   useEffect(() => {
     function clearDebounce() {
       if (timer.current) {
@@ -36,7 +61,6 @@ export function CommunityFilters() {
   const searchParams = useSearchParams();
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Initialize with defaults
   const [filters, setFilters] = useState<Filters>(() => {
     const params = searchParams;
     const statusParam = params.get('status');
@@ -44,24 +68,26 @@ export function CommunityFilters() {
       search: params.get('search') || undefined,
       country: params.get('country') || undefined,
       status: statusParam ? (statusParam as Filters['status']) : 'all',
-      cois_tier: params.get('tier') as Filters['cois_tier'] || undefined,
+      cois_tier: (params.get('tier') as Filters['cois_tier']) || undefined,
       verified_only: params.get('verified') === 'true',
       has_upcoming_events: params.get('upcoming') === 'true',
-      event_types: params.get('types')?.split(',').filter(Boolean) as EventType[] || [],
+      event_types:
+        (params.get('types')?.split(',').filter(Boolean) as EventType[]) || [],
     };
   });
 
-  const updateFilter = <K extends keyof Filters>(key: K, value: Filters[K], debounce = false) => {
+  const updateFilter = <K extends keyof Filters>(
+    key: K,
+    value: Filters[K],
+    debounce = false,
+  ) => {
     const newFilters = { ...filters, [key]: value };
     setFilters(newFilters);
 
     if (debounce) {
-      // Clear existing timer
       if (debounceTimer.current) {
         clearTimeout(debounceTimer.current);
       }
-
-      // Set new timer
       debounceTimer.current = setTimeout(() => {
         applyFilters(newFilters);
       }, 300);
@@ -86,24 +112,14 @@ export function CommunityFilters() {
     if (newFilters.cois_tier) params.set('tier', newFilters.cois_tier);
     if (newFilters.has_upcoming_events) params.set('upcoming', 'true');
 
-    // Add event types if any are selected
     if (newFilters.event_types && newFilters.event_types.length > 0) {
       params.set('types', newFilters.event_types.join(','));
-      console.log('🔍 Event types filter:', newFilters.event_types);
     }
 
     const queryString = params.toString();
-    router.push(queryString ? `/communities?${queryString}` : '/communities', { scroll: false });
-  };
-
-  const toggleEventType = (type: EventType) => {
-    const current = filters.event_types || [];
-    const updated = current.includes(type)
-      ? current.filter((t) => t !== type)
-      : [...current, type];
-    const newFilters = { ...filters, event_types: updated };
-    setFilters(newFilters);
-    applyFilters(newFilters);
+    router.push(queryString ? `/communities?${queryString}` : '/communities', {
+      scroll: false,
+    });
   };
 
   const clearFilters = () => {
@@ -126,51 +142,10 @@ export function CommunityFilters() {
     (filters.status && filters.status !== 'all');
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-foreground">Filters</h3>
-        {hasActiveFilters && (
-          <RFDS.SemanticButton
-            variant="ghost"
-            size="sm"
-            onClick={clearFilters}
-            className="text-sm"
-          >
-            Clear all
-          </RFDS.SemanticButton>
-        )}
-      </div>
-
-      {/* Status shortcuts */}
-      <div>
-        <label className="block text-sm font-medium text-foreground mb-3">
-          Status
-        </label>
-        <div className="flex flex-wrap gap-2">
-          {STATUS_OPTIONS.map((option) => {
-            const selected = (filters.status || 'all') === option.value;
-
-            return (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => updateFilter('status', option.value)}
-                className={selected
-                  ? 'rounded-full bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition'
-                  : 'rounded-full border border-border bg-card px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:border-primary hover:text-primary'
-                }
-              >
-                {option.label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
+    <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
       {/* Search */}
-      <div>
-        <label className="block text-sm font-medium text-foreground mb-2">
+      <div className="flex-1 sm:min-w-[220px]">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Search
         </label>
         <RFDS.SearchInput
@@ -181,67 +156,49 @@ export function CommunityFilters() {
         />
       </div>
 
-      {/* Event Types */}
-      <div>
-        <label className="block text-sm font-medium text-foreground mb-3">
-          Event Types
-        </label>
-        <div className="space-y-2">
-          {(['meetup', 'conference', 'workshop', 'hackathon', 'virtual'] as EventType[]).map(
-            (type) => (
-              <label key={type} className="flex items-center gap-2 cursor-pointer group">
-                <RFDS.Checkbox
-                  checked={filters.event_types?.includes(type) || false}
-                  onChange={() => toggleEventType(type)}
-                  className="w-4 h-4"
-                />
-                <span className="text-sm text-foreground capitalize group-hover:text-primary transition">
-                  {type}
-                </span>
-              </label>
-            )
-          )}
-        </div>
-      </div>
-
-      {/* CoIS Tier */}
-      <div>
+      {/* Status */}
+      <div className="sm:w-40">
         <SortDropdown
-          label="CoIS Tier"
-          options={[
-            { value: '', label: '🎯 All Tiers' },
-            { value: 'platinum', label: '💎 Platinum' },
-            { value: 'gold', label: '🏆 Gold' },
-            { value: 'silver', label: '🥈 Silver' },
-            { value: 'bronze', label: '🥉 Bronze' },
-          ]}
-          value={filters.cois_tier || ''}
-          onChange={(value) => updateFilter('cois_tier', value as Filters['cois_tier'])}
+          label="Status"
+          options={STATUS_OPTIONS}
+          value={(filters.status as string) || 'all'}
+          onChange={(value) => updateFilter('status', value as Filters['status'])}
         />
       </div>
 
-      {/* Toggles */}
-      {/* <div className="space-y-3 pt-2 border-t border-border">
+      {/* Event type */}
+      <div className="sm:w-44">
+        <SortDropdown
+          label="Event type"
+          options={EVENT_TYPE_OPTIONS}
+          value={filters.event_types?.[0] || ''}
+          onChange={(value) =>
+            updateFilter('event_types', value ? [value as EventType] : [])
+          }
+        />
+      </div>
 
-        <label className="flex items-center gap-2 cursor-pointer group">
-          <input
-            checked={filters.has_upcoming_events || false}
-            onChange={(e) => {
-              console.log('📅 Has upcoming events toggled:', e.target.checked);
-              updateFilter('has_upcoming_events', e.target.checked);
-            }}
-            className="w-4 h-4 rounded border-border text-primary focus:ring-2 focus:ring-primary"
-          />
-          <span className="text-sm text-foreground group-hover:text-primary transition">
-            Recent activity (last 6 months)
-          </span>
-        </label>
-      </div> */}
+      {/* Tier */}
+      <div className="sm:w-40">
+        <SortDropdown
+          label="Tier"
+          options={TIER_OPTIONS}
+          value={filters.cois_tier || ''}
+          onChange={(value) =>
+            updateFilter('cois_tier', (value || undefined) as Filters['cois_tier'])
+          }
+        />
+      </div>
 
-      {/* Apply button (for mobile) */}
-      <RFDS.SemanticButton variant="primary" className="w-full lg:hidden">
-        Apply Filters
-      </RFDS.SemanticButton>
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={clearFilters}
+          className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:pb-2.5"
+        >
+          Clear
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/communities/CommunityList.tsx
+++ b/src/components/communities/CommunityList.tsx
@@ -117,19 +117,13 @@ const FALLBACK_COMMUNITIES: Community[] = [
 export function CommunityList() {
   const searchParams = useSearchParams();
 
-  // Build query string from search params
   const queryString = searchParams.toString();
   const apiUrl = `/api/communities${queryString ? `?${queryString}` : ''}`;
 
-  // Fetch communities from API with filters
-  const { data, error, isLoading } = useSWR(
-    apiUrl,
-    fetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
+  const { data, error, isLoading } = useSWR(apiUrl, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
 
   const communities: Community[] = data?.communities || FALLBACK_COMMUNITIES;
 
@@ -137,7 +131,7 @@ export function CommunityList() {
     return (
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-48 bg-muted animate-pulse rounded-xl" />
+          <div key={i} className="h-40 animate-pulse rounded-2xl bg-muted" />
         ))}
       </div>
     );
@@ -145,25 +139,29 @@ export function CommunityList() {
 
   if (error) {
     return (
-      <div className="text-center py-12 bg-destructive/10 rounded-lg">
-        <p className="text-destructive font-medium mb-2">Failed to load communities</p>
-        <p className="text-sm text-muted-foreground">Please try refreshing the page</p>
+      <div className="rounded-2xl border border-border/60 bg-card p-8 text-center">
+        <p className="font-medium text-destructive">Failed to load communities</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Please try refreshing the page
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground mb-4">
-        Showing {communities.length} React communities worldwide
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        {communities.length} communities worldwide
       </p>
 
-      {communities.map((community) => (
-        <CommunityCard key={community.id} community={community} />
-      ))}
+      <div className="space-y-4">
+        {communities.map((community) => (
+          <CommunityCard key={community.id} community={community} />
+        ))}
+      </div>
 
       {communities.length === 0 && (
-        <div className="text-center py-12 bg-muted/30 rounded-lg">
+        <div className="rounded-2xl border border-border/60 bg-card p-12 text-center">
           <p className="text-muted-foreground">No communities found</p>
         </div>
       )}
@@ -172,134 +170,117 @@ export function CommunityList() {
 }
 
 function CommunityCard({ community }: { community: Community }) {
-  const tierBadge = getTierBadge(community.cois_tier);
+  const tier = getTierBadge(community.cois_tier);
+  const initials = community.name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0])
+    .join('')
+    .toUpperCase();
 
   return (
-    <div className="bg-card border border-border rounded-lg p-6 hover:shadow-lg transition">
-      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-        {/* Main Info */}
-        <div className="flex-1">
-          <div className="flex items-start gap-3 mb-2">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-1 flex-wrap">
-                <h3 className="text-xl font-bold text-foreground">
-                  {community.name}
-                </h3>
-                <VerificationBadge
-                  verified={community.verified}
-                  status={community.verification_status}
-                  size="sm"
-                />
-              </div>
-              <p className="text-sm text-muted-foreground">
-                {community.city}
-                {community.region && `, ${community.region}`}, {community.country}
-              </p>
-            </div>
-            {tierBadge && (
-              <span className={`px-3 py-1 rounded-full text-xs font-medium ${tierBadge.className}`}>
-                {tierBadge.icon} {tierBadge.label}
-              </span>
-            )}
-          </div>
+    <div className="flex flex-col gap-5 rounded-2xl border border-border/60 bg-card p-6 transition-colors hover:border-border sm:flex-row">
+      {/* Logo */}
+      <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-muted text-lg font-semibold text-muted-foreground">
+        {initials}
+      </div>
 
-          <p className="text-foreground mb-4 line-clamp-2">
-            {community.description}
-          </p>
-
-          {/* Stats */}
-          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-            <div className="flex items-center gap-1">
-              <span>👥</span>
-              <span>{community.member_count.toLocaleString()} members</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <span>📅</span>
-              <span className="capitalize">{community.meeting_frequency}</span>
-            </div>
-            {community.last_event_date && (
-              <div className="flex items-center gap-1">
-                <span>🎯</span>
-                <span>Last event: {new Date(community.last_event_date).toLocaleDateString()}</span>
-              </div>
-            )}
-          </div>
-
-          {/* Event Types */}
-          <div className="flex gap-2 mt-3">
-            {community.event_types.map((type) => (
-              <span
-                key={type}
-                className="px-2 py-1 bg-primary/10 text-primary rounded text-xs capitalize"
-              >
-                {type}
-              </span>
-            ))}
-          </div>
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-lg font-semibold text-foreground">{community.name}</h3>
+          <VerificationBadge
+            verified={community.verified}
+            status={community.verification_status}
+            size="sm"
+          />
+          {tier && (
+            <span
+              className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${tier.className}`}
+            >
+              {tier.label}
+            </span>
+          )}
         </div>
 
-        {/* Actions */}
-        <div className="flex md:flex-col gap-2">
-          <Link
-            href={`/communities/${community.slug}`}
-            className="flex-1 md:flex-none text-center bg-primary text-primary-foreground rounded-lg px-4 py-2 font-medium hover:bg-primary/90 transition whitespace-nowrap block"
-          >
-            View Details
-          </Link>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {community.city}
+          {community.region && `, ${community.region}`}, {community.country}
+        </p>
+
+        <p className="mt-3 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+          {community.description}
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+          <span>{community.member_count.toLocaleString()} members</span>
+          <span aria-hidden="true">·</span>
+          <span className="capitalize">{community.meeting_frequency}</span>
+          {community.last_event_date && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>
+                Last event:{' '}
+                {new Date(community.last_event_date).toLocaleDateString()}
+              </span>
+            </>
+          )}
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-3">
           {community.meetup_url ? (
             <a
               href={community.meetup_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-1 md:flex-none text-center bg-[#ED1C40] text-white rounded-lg px-4 py-2 font-medium hover:bg-[#ED1C40]/90 transition whitespace-nowrap flex items-center justify-center gap-2"
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
             >
-              <svg className="w-4 h-4" viewBox="0 0 512 512" fill="currentColor">
-                <path d="M99 414.3c1.1 5.7-2.3 11.1-8 12.3-5.4 1.1-10.9-2.3-12-8-1.1-5.4 2.3-11 7.7-12 5.4-1.2 11.1 2.3 12.3 7.7zm143.1 71.4c-6.3 4.6-8 13.4-3.7 20 4.6 6.6 13.4 8.3 20 3.7 6.3-4.6 8-13.4 3.4-20-4.2-6.5-13.1-8.2-19.7-3.7zm-86-462.3c6.3-1.4 10.3-7.7 8.9-14-1.1-6.6-7.4-10.6-13.7-9.1-6.3 1.4-10.3 7.7-9.1 14 1.4 6.6 7.6 10.6 13.9 9.1zM34.4 226.3c-10-6.9-23.7-4.3-30.6 6-6.9 10-4.3 24 5.7 30.9 10 7.1 23.7 4.6 30.6-5.7 6.9-10.4 4.3-24.1-5.7-31.2zm272-170.9c10.6-6.3 13.7-20 7.7-30.3-6.3-10.6-19.7-14-30-7.7s-13.7 20-7.4 30.6c6 10.3 19.4 13.7 29.7 7.4zm-191.1 58.6c7.7-5.4 9.4-16 4.3-23.7s-15.7-9.4-23.1-4.3c-7.7 5.4-9.4 16-4.3 23.7 5.1 7.8 15.6 9.5 23.1 4.3zm372.3 156c-7.4 1.7-12.3 9.1-10.6 16.9 1.4 7.4 8.9 12.3 16.3 10.6 7.4-1.4 12.3-8.9 10.6-16.6-1.5-7.4-8.9-12.3-16.3-10.9zm39.7-56.8c-1.1-5.7-6.6-9.1-12-8-5.7 1.1-9.1 6.9-8 12.6 1.1 5.4 6.6 9.1 12.3 8 5.4-1.5 9.1-6.9 7.7-12.6zM447 138.9c-8.6 6-10.6 17.7-4.9 26.3 6 8.6 17.4 10.6 26 4.9 8.3-6 10.3-17.7 4.6-26.3-6-8.5-17.4-10.6-25.7-4.9zm-6.3 139.4c26.3 43.1 15.1 100-26.3 129.1-17.4 12.3-37.1 17.7-56.9 17.1-12 47.1-69.4 64.6-105.1 32.6-1.1.9-2.6 1.7-3.7 2.9-39.1 27.1-92.3 17.4-119.4-22.3-9.7-14.3-14.6-30.6-15.1-46.9-65.4-10.9-90-94-41.1-139.7-28.3-46.9.6-107.4 53.4-114.9C151.6 70.2 213.3 4.6 277.1 2 338.5.3 395.2 28.5 425.5 70.7c36.3 48.6 42.6 63.4 57.7 84.6 12.3 17.1 15.1 37.4 15.1 58.3 0 21.7-7.7 42.3-15.1 61.7-8.3 19.4-20.6 37.1-35.1 52.6-2.3 2.3-4.6 4.6-6.9 6.9 2.3 2.3 5.1 5.1 7.7 7.4 20.6 19.7 49.7 29.1 78.3 23.4 6.3-1.1 12.3 3.1 13.4 9.4 1.1 6.3-3.1 12.3-9.4 13.4-34.9 7.1-71.1-4.9-96.6-30z"/>
+              <svg
+                className="h-4 w-4 text-muted-foreground"
+                viewBox="0 0 512 512"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M99 414.3c1.1 5.7-2.3 11.1-8 12.3-5.4 1.1-10.9-2.3-12-8-1.1-5.4 2.3-11 7.7-12 5.4-1.2 11.1 2.3 12.3 7.7zm143.1 71.4c-6.3 4.6-8 13.4-3.7 20 4.6 6.6 13.4 8.3 20 3.7 6.3-4.6 8-13.4 3.4-20-4.2-6.5-13.1-8.2-19.7-3.7zm-86-462.3c6.3-1.4 10.3-7.7 8.9-14-1.1-6.6-7.4-10.6-13.7-9.1-6.3 1.4-10.3 7.7-9.1 14 1.4 6.6 7.6 10.6 13.9 9.1zM34.4 226.3c-10-6.9-23.7-4.3-30.6 6-6.9 10-4.3 24 5.7 30.9 10 7.1 23.7 4.6 30.6-5.7 6.9-10.4 4.3-24.1-5.7-31.2zm272-170.9c10.6-6.3 13.7-20 7.7-30.3-6.3-10.6-19.7-14-30-7.7s-13.7 20-7.4 30.6c6 10.3 19.4 13.7 29.7 7.4zm-191.1 58.6c7.7-5.4 9.4-16 4.3-23.7s-15.7-9.4-23.1-4.3c-7.7 5.4-9.4 16-4.3 23.7 5.1 7.8 15.6 9.5 23.1 4.3zm372.3 156c-7.4 1.7-12.3 9.1-10.6 16.9 1.4 7.4 8.9 12.3 16.3 10.6 7.4-1.4 12.3-8.9 10.6-16.6-1.5-7.4-8.9-12.3-16.3-10.9zm39.7-56.8c-1.1-5.7-6.6-9.1-12-8-5.7 1.1-9.1 6.9-8 12.6 1.1 5.4 6.6 9.1 12.3 8 5.4-1.5 9.1-6.9 7.7-12.6zM447 138.9c-8.6 6-10.6 17.7-4.9 26.3 6 8.6 17.4 10.6 26 4.9 8.3-6 10.3-17.7 4.6-26.3-6-8.5-17.4-10.6-25.7-4.9zm-6.3 139.4c26.3 43.1 15.1 100-26.3 129.1-17.4 12.3-37.1 17.7-56.9 17.1-12 47.1-69.4 64.6-105.1 32.6-1.1.9-2.6 1.7-3.7 2.9-39.1 27.1-92.3 17.4-119.4-22.3-9.7-14.3-14.6-30.6-15.1-46.9-65.4-10.9-90-94-41.1-139.7-28.3-46.9.6-107.4 53.4-114.9C151.6 70.2 213.3 4.6 277.1 2 338.5.3 395.2 28.5 425.5 70.7c36.3 48.6 42.6 63.4 57.7 84.6 12.3 17.1 15.1 37.4 15.1 58.3 0 21.7-7.7 42.3-15.1 61.7-8.3 19.4-20.6 37.1-35.1 52.6z" />
               </svg>
-              Join on {getCommunityHostLabel(community.meetup_url)}
+              {getCommunityHostLabel(community.meetup_url)}
             </a>
-          ) : community.website && (
+          ) : community.website ? (
             <a
               href={community.website}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-1 md:flex-none text-center bg-secondary text-secondary-foreground rounded-lg px-4 py-2 font-medium hover:bg-secondary/90 transition whitespace-nowrap"
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
             >
-              Visit Website →
+              Visit website →
             </a>
-          )}
+          ) : null}
+
+          <Link
+            href={`/communities/${community.slug}`}
+            className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Learn more →
+          </Link>
         </div>
       </div>
     </div>
   );
 }
 
-function getTierBadge(tier?: string): { icon: string; label: string; className: string } | null {
+function getTierBadge(
+  tier?: string,
+): { label: string; className: string } | null {
   switch (tier) {
     case 'platinum':
-      return {
-        icon: '💎',
-        label: 'Platinum',
-        className: 'bg-gradient-to-r from-cyan-400 to-blue-400 text-white',
-      };
+      return { label: 'Platinum', className: 'bg-primary/10 text-primary' };
     case 'gold':
-      return {
-        icon: '🏆',
-        label: 'Gold',
-        className: 'bg-gradient-to-r from-yellow-400 to-orange-400 text-white',
-      };
+      return { label: 'Gold', className: 'bg-warning/15 text-warning' };
     case 'silver':
-      return {
-        icon: '🥈',
-        label: 'Silver',
-        className: 'bg-gradient-to-r from-gray-300 to-gray-400 text-white',
-      };
+      return { label: 'Silver', className: 'bg-foreground/10 text-muted-foreground' };
     case 'bronze':
-      return {
-        icon: '🥉',
-        label: 'Bronze',
-        className: 'bg-gradient-to-r from-orange-300 to-orange-400 text-white',
-      };
+      return { label: 'Bronze', className: 'bg-destructive/10 text-destructive' };
     default:
       return null;
   }

--- a/src/components/communities/CommunityList.tsx
+++ b/src/components/communities/CommunityList.tsx
@@ -7,10 +7,30 @@
 
 import useSWR from 'swr';
 import Link from 'next/link';
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { getCommunityHostLabel } from '@/lib/community-host';
+import { ReactAtom } from '@/components/ui/react-atom';
 import { VerificationBadge } from './VerificationBadge';
 import type { Community } from '@/types/community';
+
+// Decorative cover gradients used when a community has no cover_image yet.
+// Keyed deterministically off the slug so each community keeps a stable look.
+const COVER_GRADIENTS = [
+  'from-primary to-primary/40',
+  'from-success to-success/40',
+  'from-warning to-warning/40',
+  'from-destructive to-destructive/40',
+  'from-primary/70 via-accent to-success/50',
+];
+
+function coverGradient(slug: string): string {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i += 1) {
+    hash = (hash + slug.charCodeAt(i)) % COVER_GRADIENTS.length;
+  }
+  return COVER_GRADIENTS[hash];
+}
 
 // Fetcher for SWR
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
@@ -180,14 +200,32 @@ function CommunityCard({ community }: { community: Community }) {
     .toUpperCase();
 
   return (
-    <div className="flex flex-col gap-5 rounded-2xl border border-border/60 bg-card p-6 transition-colors hover:border-border sm:flex-row">
-      {/* Logo */}
-      <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-muted text-lg font-semibold text-muted-foreground">
-        {initials}
+    <div className="group flex flex-col overflow-hidden rounded-3xl border border-border/60 bg-card transition-colors hover:border-border sm:flex-row">
+      {/* Cover */}
+      <div className="relative h-44 w-full shrink-0 overflow-hidden bg-muted sm:h-auto sm:w-56 sm:self-stretch">
+        {community.cover_image ? (
+          <Image
+            src={community.cover_image}
+            alt={`${community.name} cover`}
+            fill
+            unoptimized
+            sizes="(min-width: 640px) 224px, 100vw"
+            className="object-cover"
+          />
+        ) : (
+          <div
+            className={`absolute inset-0 flex items-center justify-center bg-gradient-to-br ${coverGradient(community.slug)}`}
+          >
+            <ReactAtom className="h-12 w-12 text-white/30" strokeWidth={0.8} />
+            <span className="absolute left-4 top-4 text-lg font-semibold text-white/90">
+              {initials}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Content */}
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 p-6 sm:p-7">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-lg font-semibold text-foreground">{community.name}</h3>
           <VerificationBadge

--- a/src/components/communities/CommunityMap.tsx
+++ b/src/components/communities/CommunityMap.tsx
@@ -197,27 +197,18 @@ export function CommunityMap() {
     if (typeof window === 'undefined') return undefined;
 
     const color = getTierColorHex(tier, status);
-    const icon = getTierIcon(tier || 'none', status);
+    const dimmed = status === 'inactive' || status === 'paused';
 
-    // Create a custom SVG icon with tier color
+    // Clean teardrop pin with a white ring and solid tier-colored core.
     const svgIcon = `
-      <svg width="32" height="44" viewBox="0 0 32 44" xmlns="http://www.w3.org/2000/svg">
-        <!-- Drop shadow -->
-        <ellipse cx="16" cy="42" rx="8" ry="2" fill="rgba(0,0,0,0.2)"/>
-
-        <!-- Pin shape -->
-        <path d="M16 0C9.373 0 4 5.373 4 12c0 8 12 28 12 28s12-20 12-28c0-6.627-5.373-12-12-12z"
+      <svg width="30" height="40" viewBox="0 0 30 40" xmlns="http://www.w3.org/2000/svg" style="opacity:${dimmed ? 0.65 : 1}">
+        <ellipse cx="15" cy="38" rx="6" ry="1.8" fill="rgba(0,0,0,0.18)"/>
+        <path d="M15 1C8.096 1 2.5 6.596 2.5 13.5c0 8.5 12.5 24 12.5 24s12.5-15.5 12.5-24C27.5 6.596 21.904 1 15 1z"
               fill="${color}"
               stroke="#ffffff"
               stroke-width="2.5"
-              stroke-linecap="round"
               stroke-linejoin="round"/>
-
-        <!-- Inner circle -->
-        <circle cx="16" cy="12" r="7" fill="#ffffff" opacity="0.95"/>
-
-        <!-- Tier emoji -->
-        <text x="16" y="16" text-anchor="middle" font-size="10" fill="${color}">${icon}</text>
+        <circle cx="15" cy="13.5" r="4.5" fill="#ffffff"/>
       </svg>
     `;
 
@@ -225,22 +216,21 @@ export function CommunityMap() {
     return {
       html: svgIcon,
       className: 'custom-marker-icon',
-      iconSize: [32, 44] as [number, number],
-      iconAnchor: [16, 44] as [number, number],
-      popupAnchor: [0, -44] as [number, number],
+      iconSize: [30, 40] as [number, number],
+      iconAnchor: [15, 40] as [number, number],
+      popupAnchor: [0, -40] as [number, number],
     };
   };
 
   if (!isClient || isLoading || !L) {
     return (
-      <div className="w-full h-[600px] bg-gradient-to-br from-blue-100 to-green-100 dark:from-blue-900/20 dark:to-green-900/20 animate-pulse flex items-center justify-center rounded-lg border border-border">
+      <div className="flex h-[420px] w-full animate-pulse items-center justify-center bg-muted sm:h-[600px]">
         <div className="text-center">
-          <div className="text-6xl mb-4">🗺️</div>
-          <p className="text-lg font-medium text-foreground">
-            {isLoading ? 'Loading communities...' : !L ? 'Loading map library...' : 'Loading map...'}
+          <p className="text-sm font-medium text-foreground">
+            {isLoading ? 'Loading communities…' : !L ? 'Loading map library…' : 'Loading map…'}
           </p>
-          <p className="text-sm text-muted-foreground mt-2">
-            {isLoading ? `Fetching ${communities.length} communities` : 'Initializing Leaflet'}
+          <p className="mt-1 text-sm text-muted-foreground">
+            {isLoading ? `Fetching ${communities.length} communities` : 'Initializing map'}
           </p>
         </div>
       </div>
@@ -251,18 +241,11 @@ export function CommunityMap() {
     console.error('❌ Error loading communities:', error);
   }
 
-  console.log('🗺️ CommunityMap: Rendering map, isClient:', isClient);
-
   return (
-    <div className="relative w-full h-[600px] rounded-lg overflow-hidden border-2 border-primary/20 bg-blue-50 dark:bg-blue-950/20">
-      {/* Debug indicator */}
-      {/* <div className="absolute top-2 left-2 z-[999] bg-green-500 text-white px-3 py-1 rounded text-xs font-bold">
-        MAP CONTAINER VISIBLE
-      </div> */}
-
+    <div className="relative h-[420px] w-full overflow-hidden bg-muted sm:h-[600px]">
       {/* Map Legend */}
-      <div className="absolute top-4 right-4 z-10 bg-card/95 backdrop-blur-sm border border-border rounded-lg px-4 py-3 shadow-lg space-y-2">
-        <p className="text-xs font-semibold text-foreground mb-2">CoIS Tier</p>
+      <div className="absolute right-4 top-4 z-10 space-y-2 rounded-xl border border-border bg-card/95 px-4 py-3 shadow-lg backdrop-blur-sm">
+        <p className="mb-2 text-xs font-semibold text-foreground">CoIS Tier</p>
         <TierLegend tier="platinum" />
         <TierLegend tier="gold" />
         <TierLegend tier="silver" />
@@ -274,8 +257,8 @@ export function CommunityMap() {
         center={[20, 0]}
         zoom={2}
         scrollWheelZoom={true}
-        className="w-full h-full z-0"
-        style={{ height: '600px', width: '100%', zIndex: 0 }}
+        className="z-0 h-full w-full"
+        style={{ height: '100%', width: '100%', zIndex: 0 }}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -403,15 +386,15 @@ function getTierColorHex(tier?: string, status?: string): string {
 
   switch (tier) {
     case 'platinum':
-      return '#22d3ee'; // cyan-400
+      return '#0ea5e9'; // brand sky (primary)
     case 'gold':
-      return '#facc15'; // yellow-400
+      return '#f59e0b'; // amber-500
     case 'silver':
-      return '#9ca3af'; // gray-400
+      return '#94a3b8'; // slate-400
     case 'bronze':
-      return '#fb923c'; // orange-400
+      return '#b45309'; // amber-800 (bronze)
     default:
-      return '#3b82f6'; // blue-500 for active without tier
+      return '#64748b'; // slate-500 for active without tier
   }
 }
 

--- a/src/components/communities/CommunityStats.tsx
+++ b/src/components/communities/CommunityStats.tsx
@@ -6,7 +6,6 @@
 'use client';
 
 import useSWR from 'swr';
-import { RFDS } from '@/components/rfds';
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -15,11 +14,11 @@ export function CommunityStats() {
 
   if (isLoading || !data) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center max-w-5xl mx-auto">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="space-y-2">
-            <div className="h-12 bg-muted animate-pulse rounded" />
-            <div className="h-4 bg-muted animate-pulse rounded w-24 mx-auto" />
+      <div className="flex flex-wrap items-start justify-center gap-x-16 gap-y-8">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="space-y-2 text-center">
+            <div className="mx-auto h-10 w-20 animate-pulse rounded bg-muted" />
+            <div className="mx-auto h-4 w-24 animate-pulse rounded bg-muted" />
           </div>
         ))}
       </div>
@@ -28,7 +27,7 @@ export function CommunityStats() {
 
   if (error || !data.success) {
     return (
-      <div className="text-center text-destructive">
+      <div className="text-center text-sm text-destructive">
         Failed to load stats
       </div>
     );
@@ -41,42 +40,30 @@ export function CommunityStats() {
   const showActiveStat = activePercentage >= 0.75;
 
   return (
-    <div className={`grid grid-cols-2 md:grid-cols-${showActiveStat ? '4' : '3'} gap-8 text-center max-w-5xl mx-auto`}>
-      <StatCard
-        number={stats.total_communities.toString()}
-        label="Communities"
-      />
-      <StatCard
-        number={stats.countries.toString()}
-        label="Countries"
-      />
-      <StatCard
-        number={formatNumber(stats.total_members)}
-        label="Total Members"
-      />
+    <div className="flex flex-wrap items-start justify-center gap-x-16 gap-y-8">
+      <Stat number={stats.total_communities.toString()} label="Communities" />
+      <Stat number={stats.countries.toString()} label="Countries" />
+      <Stat number={formatNumber(stats.total_members)} label="Members" />
       {showActiveStat && (
-        <StatCard
-          number={stats.active_communities.toString()}
-          label="Active"
-        />
+        <Stat number={stats.active_communities.toString()} label="Active" />
       )}
     </div>
   );
 }
 
-function StatCard({ number, label }: { number: string; label: string }) {
+function Stat({ number, label }: { number: string; label: string }) {
   return (
-    <RFDS.StatCard
-      label={label}
-      value={number}
-      color="primary"
-      variant="default"
-    />
+    <div className="text-center">
+      <div className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+        {number}
+      </div>
+      <div className="mt-1 text-sm text-muted-foreground">{label}</div>
+    </div>
   );
 }
 
 function formatNumber(num: number): string {
   if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(0)}K+`;
+  if (num >= 1000) return `${(num / 1000).toFixed(0)}k+`;
   return num.toString();
 }

--- a/src/components/home/become-contributor.tsx
+++ b/src/components/home/become-contributor.tsx
@@ -79,43 +79,41 @@ export function BecomeContributor() {
   return (
     <section id="contribute" className="scroll-mt-32">
       <div className="text-center">
-        <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+        <h2 className="text-3xl font-semibold tracking-tight text-foreground">
           Become a Contributor
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
-          Contribute code, organize communities, create educational content, or
-          support financially — every pathway helps build a stronger ecosystem.
-        </p>
       </div>
 
-      <div className="mt-12 grid gap-6 sm:grid-cols-2">
+      <div className="mt-10 grid gap-5 sm:grid-cols-2">
         {CONTRIBUTORS.map((item) => (
           <div
             key={item.title}
-            className={`flex flex-col rounded-3xl p-8 ${
+            className={`flex flex-col justify-between gap-14 rounded-[2.5rem] p-10 ${
               item.highlighted
                 ? "bg-primary text-primary-foreground"
-                : "border border-border/60 bg-muted/50"
+                : "bg-muted/60"
             }`}
           >
-            <span className={item.iconAccent}>{item.icon}</span>
-            <h3
-              className={`mt-5 text-lg font-semibold ${
-                item.highlighted ? "text-primary-foreground" : "text-foreground"
-              }`}
-            >
-              {item.title}
-            </h3>
-            <p
-              className={`mt-3 flex-1 text-sm leading-relaxed ${
-                item.highlighted ? "text-primary-foreground/80" : "text-muted-foreground"
-              }`}
-            >
-              {item.description}
-            </p>
+            <div>
+              <span className={item.iconAccent}>{item.icon}</span>
+              <h3
+                className={`mt-4 text-base font-semibold tracking-tight ${
+                  item.highlighted ? "text-primary-foreground" : "text-foreground"
+                }`}
+              >
+                {item.title}
+              </h3>
+              <p
+                className={`mt-2 text-sm leading-relaxed ${
+                  item.highlighted ? "text-primary-foreground/80" : "text-muted-foreground"
+                }`}
+              >
+                {item.description}
+              </p>
+            </div>
             <Link
               href={item.action.href}
-              className={`mt-6 text-sm font-medium transition-colors ${
+              className={`text-sm font-medium transition-colors ${
                 item.highlighted
                   ? "text-primary-foreground hover:text-primary-foreground/80"
                   : "text-primary hover:text-primary/80"

--- a/src/components/home/become-contributor.tsx
+++ b/src/components/home/become-contributor.tsx
@@ -1,200 +1,133 @@
-'use client';
-
-import React from "react";
-import { RFDS } from "@/components/rfds";
 import Link from "next/link";
+import type { ReactNode } from "react";
 
-type Action = { href: string; label: string; external?: boolean };
-
-const contributorData: {
-  variant: 'code' | 'donate' | 'sponsor' | 'member';
+type Contributor = {
   title: string;
   description: string;
-  icon: React.ReactNode;
-  primaryAction: Action;
-  secondaryAction: Action | null;
-}[] = [
+  action: { href: string; label: string; external?: boolean };
+  iconAccent: string;
+  icon: ReactNode;
+  highlighted?: boolean;
+};
+
+const iconPaths = {
+  code: "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4",
+  support:
+    "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
+  heart:
+    "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z",
+  member:
+    "M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14c-3.866 0-7 2.239-7 5v1h14v-1c0-2.761-3.134-5-7-5z",
+};
+
+function Icon({ path, className }: { path: string; className: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d={path} />
+    </svg>
+  );
+}
+
+const CONTRIBUTORS: Contributor[] = [
   {
-    variant: 'code',
-    title: 'Contribute to Repos',
+    title: "Contribute to Repos",
     description:
-      'Submit code, RFCs, proposals, documentation, or bug reports to React and 54+ ecosystem libraries. Your contributions directly improve the tools millions of developers use.',
-    icon: (
-      <svg
-        className="h-7 w-7"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-        />
-      </svg>
-    ),
-    primaryAction: {
-      href: 'https://github.com/facebook/react',
-      label: 'Browse React Repos →',
-    },
-    secondaryAction: {
-      href: 'https://github.com/reactjs/rfcs',
-      label: 'View RFCs',
-    },
+      "Submit code, RFCs, proposals, documentation, or bug reports to React and 54+ ecosystem libraries. Your contributions directly improve the tools millions of developers use.",
+    action: { href: "https://github.com/facebook/react", label: "Browse repos →", external: true },
+    iconAccent: "text-success",
+    icon: <Icon path={iconPaths.code} className="h-6 w-6" />,
   },
   {
-    variant: 'donate' as const,
-    title: 'Support Financially',
+    title: "Support Financially",
     description:
-      'Financial support is one way to help fund maintainers, educational resources, and accessibility initiatives. This includes store purchases, direct donations, and sponsorships.',
-    icon: (
-      <svg
-        className="h-7 w-7"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-    ),
-    primaryAction: {
-      href: '/store',
-      label: 'Learn More →',
-    },
-    secondaryAction: null,
+      "Financial support is one way to help fund maintainers, educational resources, and accessibility initiatives. This includes store purchases, direct donations, and sponsorships.",
+    action: { href: "/store", label: "Learn more →" },
+    iconAccent: "text-primary",
+    icon: <Icon path={iconPaths.support} className="h-6 w-6" />,
   },
   {
-    variant: 'sponsor' as const,
-    title: 'Sponsor a Library',
+    title: "Sponsor a Library",
     description:
-      'Directly sponsor your favorite React ecosystem library. Choose from 54 libraries including Redux, TanStack Query, React Router, and more.',
-    icon: (
-      <svg
-        className="h-7 w-7"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-        />
-      </svg>
-    ),
-    primaryAction: {
-      href: '/impact#libraries',
-      label: 'Browse Libraries →',
-    },
-    secondaryAction: {
-      href: '#',
-      label: 'GitHub Sponsors',
-    },
+      "Directly sponsor your favorite React ecosystem library. Choose from 54 libraries including Redux, TanStack Query, React Router, and more.",
+    action: { href: "/impact#libraries", label: "Browse libraries →" },
+    iconAccent: "text-destructive",
+    icon: <Icon path={iconPaths.heart} className="h-6 w-6" />,
   },
   {
-    variant: 'member' as const,
-    title: 'Become a Member',
+    title: "Become a Member",
     description:
-      'Join the React Foundation as an official member. Get voting rights on funding decisions, exclusive updates, and recognition in our community.',
-    icon: (
-      <svg
-        className="h-7 w-7"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-        />
-      </svg>
-    ),
-    primaryAction: {
-      href: 'https://enrollment.lfx.linuxfoundation.org/?project=react-foundation',
-      label: 'Apply Now →',
+      "Join the React Foundation as an official member. Get voting rights on funding decisions, exclusive updates, and recognition in our community.",
+    action: {
+      href: "https://enrollment.lfx.linuxfoundation.org/?project=react-foundation",
+      label: "Apply →",
       external: true,
     },
-    secondaryAction: {
-      href: 'https://enrollment.lfx.linuxfoundation.org/?project=react-foundation',
-      label: 'Learn More',
-      external: true,
-    },
+    iconAccent: "text-primary-foreground",
+    icon: <Icon path={iconPaths.member} className="h-6 w-6" />,
+    highlighted: true,
   },
 ];
 
 export function BecomeContributor() {
-  const handleContactClick = () => {
-    const parts = ['hello', 'react', 'foundation'];
-    window.location.href = `mailto:${parts[0]}@${parts[1]}.${parts[2]}`;
-  };
-
   return (
-    <section
-      id="contribute"
-      className="relative isolate scroll-mt-32 rounded-3xl border border-border/10 p-12"
-    >
-      <div className="absolute inset-0 -z-10 overflow-hidden rounded-3xl bg-gradient-vibrant" />
+    <section id="contribute" className="scroll-mt-32">
       <div className="text-center">
-        <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+        <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
           Become a Contributor
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-base text-foreground/70">
-          Join the movement to sustain and grow the React ecosystem. Contribute code,
-          organize communities, create educational content, or support financially —
-          every pathway helps build a stronger ecosystem.
+        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
+          Contribute code, organize communities, create educational content, or
+          support financially — every pathway helps build a stronger ecosystem.
         </p>
       </div>
 
-      <div className="mt-12 grid gap-6 lg:grid-cols-2">
-        {contributorData.map((item) => (
-          <RFDS.ContributorCard
-            key={item.variant}
-            icon={<RFDS.ContributorIcon variant={item.variant}>{item.icon}</RFDS.ContributorIcon>}
-            title={item.title}
-            description={item.description}
-            actions={
-              <>
-                <Link
-                  href={item.primaryAction.href}
-                  className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-secondary px-3 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                  {...(item.primaryAction.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                >
-                  {item.primaryAction.label}
-                </Link>
-                {item.secondaryAction && (
-                  <Link
-                    href={item.secondaryAction.href}
-                    className="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                    {...(item.secondaryAction.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                  >
-                    {item.secondaryAction.label}
-                  </Link>
-                )}
-              </>
-            }
-          />
-        ))}
-      </div>
-
-      <div className="mt-8 border-t border-border/10 pt-8 text-center">
-        <p className="text-sm text-foreground/60">
-          Questions about contributing?{" "}
-          <button
-            onClick={handleContactClick}
-            className="font-medium text-primary transition-colors hover:text-primary/80 hover:underline"
+      <div className="mt-12 grid gap-6 sm:grid-cols-2">
+        {CONTRIBUTORS.map((item) => (
+          <div
+            key={item.title}
+            className={`flex flex-col rounded-3xl p-8 ${
+              item.highlighted
+                ? "bg-primary text-primary-foreground"
+                : "border border-border/60 bg-muted/50"
+            }`}
           >
-            Get in touch
-          </button>
-        </p>
+            <span className={item.iconAccent}>{item.icon}</span>
+            <h3
+              className={`mt-5 text-lg font-semibold ${
+                item.highlighted ? "text-primary-foreground" : "text-foreground"
+              }`}
+            >
+              {item.title}
+            </h3>
+            <p
+              className={`mt-3 flex-1 text-sm leading-relaxed ${
+                item.highlighted ? "text-primary-foreground/80" : "text-muted-foreground"
+              }`}
+            >
+              {item.description}
+            </p>
+            <Link
+              href={item.action.href}
+              className={`mt-6 text-sm font-medium transition-colors ${
+                item.highlighted
+                  ? "text-primary-foreground hover:text-primary-foreground/80"
+                  : "text-primary hover:text-primary/80"
+              }`}
+              {...(item.action.external
+                ? { target: "_blank", rel: "noopener noreferrer" }
+                : {})}
+            >
+              {item.action.label}
+            </Link>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/components/home/community-gallery.tsx
+++ b/src/components/home/community-gallery.tsx
@@ -1,0 +1,41 @@
+import { ReactAtom } from "@/components/ui/react-atom";
+
+/**
+ * Decorative band of community "moments". These are neutral placeholder tiles —
+ * swap the gradient fill for real event photography (object-cover <Image />) when
+ * assets are available; the labels and layout are production-ready.
+ */
+const MOMENTS: { label: string; place: string; tilt: string }[] = [
+  { label: "React India", place: "Goa", tilt: "-rotate-6 translate-y-4" },
+  { label: "React Conf", place: "Las Vegas", tilt: "rotate-3 -translate-y-2" },
+  { label: "React Native EU", place: "Wrocław", tilt: "-rotate-2 translate-y-1" },
+  { label: "React Prague", place: "Prague", tilt: "rotate-6 -translate-y-3" },
+  { label: "React TLV", place: "Tel Aviv", tilt: "-rotate-3 translate-y-3" },
+];
+
+export function CommunityGallery() {
+  return (
+    <section aria-label="Moments from the React community" className="overflow-hidden">
+      <div className="flex items-center justify-center gap-3 sm:gap-4">
+        {MOMENTS.map((moment) => (
+          <figure
+            key={moment.label}
+            className={`relative aspect-[4/5] w-40 shrink-0 overflow-hidden rounded-2xl border border-border/60 bg-muted shadow-sm transition-transform duration-300 hover:rotate-0 hover:translate-y-0 sm:w-48 ${moment.tilt}`}
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-muted to-accent" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <ReactAtom
+                className="h-10 w-10 text-muted-foreground/25"
+                strokeWidth={0.8}
+              />
+            </div>
+            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/85 via-background/50 to-transparent p-3 text-left">
+              <p className="text-xs font-semibold text-foreground">{moment.label}</p>
+              <p className="text-[11px] text-muted-foreground">{moment.place}</p>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/community-gallery.tsx
+++ b/src/components/home/community-gallery.tsx
@@ -1,37 +1,43 @@
 import { ReactAtom } from "@/components/ui/react-atom";
 
 /**
- * Decorative band of community "moments". These are neutral placeholder tiles —
- * swap the gradient fill for real event photography (object-cover <Image />) when
- * assets are available; the labels and layout are production-ready.
+ * Hero band of large, alternately-tilted community "moments" — mirrors the Figma's
+ * overlapping photo strip. These are neutral placeholder tiles: swap the gradient
+ * fill for real event photography (object-cover <Image />) when assets are
+ * available; the labels, tilt, and layout are production-ready.
  */
 const MOMENTS: { label: string; place: string; tilt: string }[] = [
-  { label: "React India", place: "Goa", tilt: "-rotate-6 translate-y-4" },
-  { label: "React Conf", place: "Las Vegas", tilt: "rotate-3 -translate-y-2" },
-  { label: "React Native EU", place: "Wrocław", tilt: "-rotate-2 translate-y-1" },
-  { label: "React Prague", place: "Prague", tilt: "rotate-6 -translate-y-3" },
-  { label: "React TLV", place: "Tel Aviv", tilt: "-rotate-3 translate-y-3" },
+  { label: "React India", place: "Goa", tilt: "-rotate-6" },
+  { label: "React Conf", place: "Las Vegas", tilt: "rotate-6" },
+  { label: "React Native EU", place: "Wrocław", tilt: "-rotate-6" },
+  { label: "React Prague", place: "Prague", tilt: "rotate-6" },
+  { label: "React TLV", place: "Tel Aviv", tilt: "-rotate-6" },
 ];
 
 export function CommunityGallery() {
   return (
-    <section aria-label="Moments from the React community" className="overflow-hidden">
-      <div className="flex items-center justify-center gap-3 sm:gap-4">
+    <section
+      aria-label="Moments from the React community"
+      className="overflow-hidden"
+    >
+      <div className="flex items-center justify-center gap-5 sm:gap-8">
         {MOMENTS.map((moment) => (
           <figure
             key={moment.label}
-            className={`relative aspect-[4/5] w-40 shrink-0 overflow-hidden rounded-2xl border border-border/60 bg-muted shadow-sm transition-transform duration-300 hover:rotate-0 hover:translate-y-0 sm:w-48 ${moment.tilt}`}
+            className={`relative aspect-[3/2] w-64 shrink-0 overflow-hidden rounded-[1.75rem] border border-border/50 bg-muted shadow-[0_14px_24px_0_rgba(0,0,0,0.15)] transition-transform duration-300 hover:rotate-0 sm:w-80 ${moment.tilt}`}
           >
             <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-muted to-accent" />
             <div className="absolute inset-0 flex items-center justify-center">
               <ReactAtom
-                className="h-10 w-10 text-muted-foreground/25"
+                className="h-12 w-12 text-muted-foreground/25"
                 strokeWidth={0.8}
               />
             </div>
-            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/85 via-background/50 to-transparent p-3 text-left">
-              <p className="text-xs font-semibold text-foreground">{moment.label}</p>
-              <p className="text-[11px] text-muted-foreground">{moment.place}</p>
+            <figcaption className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/85 via-background/50 to-transparent p-4 text-left">
+              <p className="text-sm font-semibold text-foreground">
+                {moment.label}
+              </p>
+              <p className="text-xs text-muted-foreground">{moment.place}</p>
             </figcaption>
           </figure>
         ))}

--- a/src/components/home/executive-message.tsx
+++ b/src/components/home/executive-message.tsx
@@ -1,110 +1,107 @@
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
 import Image from "next/image";
 
 export function ExecutiveMessage() {
   return (
-    <ScrollReveal animation="fade-up">
-      <section className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-gradient-accent p-12">
-        <div className="space-y-6 text-center">
-          <div className="flex justify-center">
-            <div className="relative h-32 w-32 shrink-0 overflow-hidden rounded-full border-4 border-border/20 bg-muted shadow-2xl">
-              <Image
-                src="/seth-webster-headshot.jpeg"
-                alt="Seth Webster, Executive Director"
-                width={128}
-                height={128}
-                className="object-cover"
-                priority
-              />
-            </div>
-          </div>
-          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-            A Message from Our Executive Director
-          </h2>
+    <section className="scroll-mt-32 rounded-[2rem] border border-border/60 bg-card p-8 sm:p-12">
+      <p className="text-sm font-semibold text-primary">
+        A Message from Our Executive Director
+      </p>
+
+      <div className="mt-8 max-w-2xl space-y-5 text-base leading-relaxed text-muted-foreground">
+        <p>
+          You know, every so often, something comes along in software that
+          changes not just how we build — but why we build.
+        </p>
+
+        <p>React did that.</p>
+
+        <p>
+          It gave us more than a way to render UIs. It gave us a new way to think
+          — about composition, about state, about expressing ideas. But even more
+          than that, it gave us a new way to connect with one another.
+        </p>
+
+        <p>
+          From the very beginning, React has been about people. About curiosity
+          shared in the open. About mentorship that crosses companies, countries,
+          and time zones. About a community that believes — deeply — that if we
+          help others bring their ideas to life, ours will follow.
+        </p>
+
+        <p>
+          That belief has powered one of the most influential movements in modern
+          software history. React has shaped how the web is built, how mobile is
+          built, even how we as developers think about creativity itself. And yet,
+          for all its reach and impact, its heart has never changed: it&apos;s
+          still about people building together.
+        </p>
+
+        <p>That&apos;s why we created the React Foundation.</p>
+
+        <p>
+          The Foundation exists to make sure React&apos;s future is independent,
+          community-driven, and open — forever. It&apos;s here to protect the
+          culture that brought us all this way, and to nurture what comes next: the
+          next generation of maintainers, educators, experimenters, and dreamers.
+        </p>
+
+        <p>
+          We&apos;re doing that by working hand-in-hand with incredible partners —
+          Meta, Microsoft, Amazon, Vercel, Expo, Callstack, Software Mansion, and
+          many more — but more importantly, by working with you, the global
+          community of developers who make React what it is.
+        </p>
+
+        <p className="text-foreground">
+          <strong className="font-semibold">
+            Because this isn&apos;t just about governance. It&apos;s about legacy.
+            <br />
+            It&apos;s about ensuring that the ideas we build together endure.
+          </strong>
+        </p>
+
+        <p>
+          I&apos;ve had the privilege of leading React at Meta for many years, and
+          now, as the Executive Director of the React Foundation, I carry the same
+          North Star that&apos;s guided me all along: helping others bring their
+          ideas to life.
+        </p>
+
+        <p>
+          If React has ever inspired you — to learn, to teach, to build, to share —
+          then you are already part of this story. The Foundation is here to help
+          that story grow, together.
+        </p>
+
+        <p>
+          Thank you for everything you&apos;ve built so far — and for everything
+          you&apos;re about to.
+        </p>
+
+        <p className="text-foreground">
+          <strong className="font-semibold">
+            Let&apos;s make the next chapter one that lasts for generations.
+          </strong>
+        </p>
+      </div>
+
+      <div className="mt-10 flex max-w-2xl items-center gap-4 border-t border-border/60 pt-8">
+        <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full border border-border">
+          <Image
+            src="/seth-webster-headshot.jpeg"
+            alt="Seth Webster, Executive Director"
+            fill
+            sizes="48px"
+            className="object-cover"
+          />
         </div>
-
-        <div className="mx-auto max-w-3xl space-y-6 leading-relaxed text-foreground">
-          <p>
-            You know, every so often, something comes along in software that changes not
-            just how we build — but why we build.
-          </p>
-
-          <p>React did that.</p>
-
-          <p>
-            It gave us more than a way to render UIs. It gave us a new way to think —
-            about composition, about state, about expressing ideas. But even more than
-            that, it gave us a new way to connect with one another.
-          </p>
-
-          <p>
-            From the very beginning, React has been about people. About curiosity shared
-            in the open. About mentorship that crosses companies, countries, and time
-            zones. About a community that believes — deeply — that if we help others
-            bring their ideas to life, ours will follow.
-          </p>
-
-          <p>
-            That belief has powered one of the most influential movements in modern
-            software history. React has shaped how the web is built, how mobile is built,
-            even how we as developers think about creativity itself. And yet, for all its
-            reach and impact, its heart has never changed: it&apos;s still about people
-            building together.
-          </p>
-
-          <p>That&apos;s why we created the React Foundation.</p>
-
-          <p>
-            The Foundation exists to make sure React&apos;s future is independent,
-            community-driven, and open — forever. It&apos;s here to protect the culture
-            that brought us all this way, and to nurture what comes next: the next
-            generation of maintainers, educators, experimenters, and dreamers.
-          </p>
-
-          <p>
-            We&apos;re doing that by working hand-in-hand with incredible partners —
-            Meta, Microsoft, Amazon, Vercel, Expo, Callstack, Software Mansion, and many
-            more — but more importantly, by working with you, the global community of
-            developers who make React what it is.
-          </p>
-
-          <p>
-            <strong className="font-semibold">
-              Because this isn&apos;t just about governance. It&apos;s about legacy.
-              <br />
-              It&apos;s about ensuring that the ideas we build together endure.
-            </strong>
-          </p>
-
-          <p>
-            I&apos;ve had the privilege of leading React at Meta for  many years, and now,
-            as the Executive Director of the React Foundation, I carry the same North Star
-            that&apos;s guided me all along: helping others bring their ideas to life.
-          </p>
-
-          <p>
-            If React has ever inspired you — to learn, to teach, to build, to share —
-            then you are already part of this story. The Foundation is here to help that
-            story grow, together.
-          </p>
-
-          <p>
-            Thank you for everything you&apos;ve built so far — and for everything
-            you&apos;re about to.
-          </p>
-
-          <p>
-            <strong className="font-semibold">Let&apos;s make the next chapter one that lasts for generations.</strong>
+        <div>
+          <p className="font-semibold text-foreground">Seth Webster</p>
+          <p className="text-sm text-muted-foreground">
+            Executive Director, React Foundation
           </p>
         </div>
-
-        <div className="border-t border-border/10 pt-8 text-center">
-          <div className="space-y-2">
-            <p className="text-lg font-semibold text-foreground">Seth Webster</p>
-            <p className="text-sm text-foreground/60">Executive Director, React Foundation</p>
-          </div>
-        </div>
-      </section>
-    </ScrollReveal>
+      </div>
+    </section>
   );
 }

--- a/src/components/home/executive-message.tsx
+++ b/src/components/home/executive-message.tsx
@@ -2,12 +2,12 @@ import Image from "next/image";
 
 export function ExecutiveMessage() {
   return (
-    <section className="scroll-mt-32 rounded-[2rem] border border-border/60 bg-card p-8 sm:p-12">
-      <p className="text-sm font-semibold text-primary">
+    <section className="scroll-mt-32 rounded-[2.5rem] border border-border/60 bg-card p-8 shadow-[0_24px_44px_-12px_rgba(0,0,0,0.08)] sm:p-12 lg:px-20 lg:py-16">
+      <p className="text-base font-semibold text-primary">
         A Message from Our Executive Director
       </p>
 
-      <div className="mt-8 max-w-2xl space-y-5 text-base leading-relaxed text-muted-foreground">
+      <div className="mt-10 space-y-5 text-lg leading-relaxed text-foreground/80">
         <p>
           You know, every so often, something comes along in software that
           changes not just how we build — but why we build.
@@ -85,7 +85,7 @@ export function ExecutiveMessage() {
         </p>
       </div>
 
-      <div className="mt-10 flex max-w-2xl items-center gap-4 border-t border-border/60 pt-8">
+      <div className="mt-10 flex items-center gap-3">
         <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full border border-border">
           <Image
             src="/seth-webster-headshot.jpeg"

--- a/src/components/home/foundation-hero.tsx
+++ b/src/components/home/foundation-hero.tsx
@@ -5,7 +5,7 @@ export function FoundationHero() {
   return (
     <section className="flex flex-col items-center pt-10 text-center sm:pt-16">
       <ReactAtom
-        className="mb-8 h-14 w-14 text-muted-foreground/40"
+        className="mb-6 h-20 w-20 text-foreground/20"
         strokeWidth={0.9}
       />
       <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">

--- a/src/components/home/foundation-hero.tsx
+++ b/src/components/home/foundation-hero.tsx
@@ -1,33 +1,27 @@
 import { ButtonLink } from "@/components/ui/button";
-import { Pill } from "@/components/ui/pill";
-import { HeroBadges } from "@/components/home/hero-badges";
+import { ReactAtom } from "@/components/ui/react-atom";
 
 export function FoundationHero() {
   return (
-    <section className="space-y-8 pt-12">
-      <Pill>Community-Driven · Transparent · Impactful</Pill>
-      <div>
-        <h1 className="text-5xl font-semibold leading-tight text-foreground sm:text-6xl lg:text-7xl">
-          Building the future of React, together.
-        </h1>
-        <p className="mt-8 max-w-2xl text-lg text-foreground/70">
-          The React Foundation is a community-driven initiative dedicated to sustaining
-          and advancing the React ecosystem. Join thousands of contributors who code,
-          teach, organize, and support the tools millions of developers rely on.
-        </p>
-      </div>
-      <div className="flex flex-wrap gap-4">
+    <section className="flex flex-col items-center pt-10 text-center sm:pt-16">
+      <ReactAtom
+        className="mb-8 h-14 w-14 text-muted-foreground/40"
+        strokeWidth={0.9}
+      />
+      <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+        Building the future of React, together.
+      </h1>
+      <p className="mt-6 max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+        The React Foundation is a community-driven initiative dedicated to
+        sustaining and advancing the React ecosystem. Join thousands of
+        contributors who code, teach, organize, and support the tools millions
+        of developers rely on.
+      </p>
+      <div className="mt-9">
         <ButtonLink href="#contribute" variant="primary" size="lg">
-          Get Involved
-        </ButtonLink>
-        <ButtonLink href="/about" variant="secondary" size="lg">
-          Learn Our Story
-        </ButtonLink>
-        <ButtonLink href="/store" variant="tertiary" size="lg">
-          Shop to Support
+          Get involved
         </ButtonLink>
       </div>
-      <HeroBadges />
     </section>
   );
 }

--- a/src/components/home/join-movement-cta.tsx
+++ b/src/components/home/join-movement-cta.tsx
@@ -1,30 +1,19 @@
 import { ButtonLink } from "@/components/ui/button";
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
 
 export function JoinMovementCTA() {
   return (
-    <ScrollReveal animation="scale">
-      <section className="scroll-mt-32 space-y-8 rounded-3xl border border-border/10 bg-gradient-to-br from-cyan-500/10 via-yellow-400/10 to-orange-500/10 p-12 text-center">
-        <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-          Join the Movement
-        </h2>
-        <p className="mx-auto max-w-2xl text-lg text-foreground/70">
-          Whether you contribute code, organize meetups, create educational content,
-          or support financially, there are many ways to participate in building a
-          sustainable future for the React ecosystem.
-        </p>
-        <div className="flex flex-wrap items-center justify-center gap-4">
-          <ButtonLink href="#contribute" variant="primary" size="lg">
-            Get Involved
-          </ButtonLink>
-          <ButtonLink href="/impact" variant="secondary" size="lg">
-            View Impact Reports
-          </ButtonLink>
-          <ButtonLink href="/store" variant="ghost" size="lg">
-            Shop the Store
-          </ButtonLink>
-        </div>
-      </section>
-    </ScrollReveal>
+    <section className="flex flex-col items-center gap-6 py-8 text-center">
+      <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+        Join the Movement
+      </h2>
+      <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
+        Whether you contribute code, organize meetups, create educational
+        content, or support financially, there are many ways to participate in
+        building a sustainable future for the React ecosystem.
+      </p>
+      <ButtonLink href="#contribute" variant="primary" size="lg">
+        Get involved
+      </ButtonLink>
+    </section>
   );
 }

--- a/src/components/home/join-movement-cta.tsx
+++ b/src/components/home/join-movement-cta.tsx
@@ -2,11 +2,11 @@ import { ButtonLink } from "@/components/ui/button";
 
 export function JoinMovementCTA() {
   return (
-    <section className="flex flex-col items-center gap-6 py-8 text-center">
-      <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+    <section className="flex flex-col items-center gap-8 py-12 text-center">
+      <h2 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
         Join the Movement
       </h2>
-      <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
+      <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
         Whether you contribute code, organize meetups, create educational
         content, or support financially, there are many ways to participate in
         building a sustainable future for the React ecosystem.

--- a/src/components/home/members-strip.tsx
+++ b/src/components/home/members-strip.tsx
@@ -1,0 +1,48 @@
+import Image from "next/image";
+import Link from "next/link";
+
+/**
+ * Founding-member logos rendered as a restrained "trusted by" strip on a light
+ * surface: grayscale by default, full color on hover. Only logos with dark/colored
+ * source art are included — callstack and software-mansion ship white-only SVGs
+ * (built for dark backgrounds) and need light-variant assets before they can join.
+ */
+const MEMBERS: { name: string; src: string; width: number }[] = [
+  { name: "Meta", src: "/assets/founding-members/meta.svg", width: 92 },
+  { name: "Microsoft", src: "/assets/founding-members/microsoft.svg", width: 130 },
+  { name: "Huawei", src: "/assets/founding-members/huawei.svg", width: 92 },
+  { name: "Amazon", src: "/assets/founding-members/amazon.svg", width: 90 },
+  { name: "Expo", src: "/assets/founding-members/expo.svg", width: 88 },
+  { name: "Vercel", src: "/assets/founding-members/vercel.svg", width: 92 },
+];
+
+export function MembersStrip() {
+  return (
+    <section className="flex flex-col items-center gap-8">
+      <Link
+        href="/about"
+        className="text-sm font-medium text-primary transition-colors hover:text-primary/80"
+      >
+        Meet our members →
+      </Link>
+      <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-6 sm:gap-x-14">
+        {MEMBERS.map((member) => (
+          <div
+            key={member.name}
+            className="relative h-7"
+            style={{ width: member.width }}
+          >
+            <Image
+              src={member.src}
+              alt={`${member.name} logo`}
+              fill
+              sizes="130px"
+              unoptimized
+              className="object-contain opacity-60 grayscale brightness-0 transition duration-300 hover:opacity-100 dark:opacity-70 dark:invert dark:hover:opacity-100"
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/mission-statement.tsx
+++ b/src/components/home/mission-statement.tsx
@@ -3,10 +3,10 @@ import { ButtonLink } from "@/components/ui/button";
 export function MissionStatement() {
   return (
     <section id="mission" className="scroll-mt-32">
-      <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
+      <p className="text-base font-semibold tracking-tight text-primary">
         Our Mission
       </p>
-      <p className="mt-6 max-w-3xl text-2xl font-medium leading-snug tracking-tight text-foreground sm:text-3xl">
+      <p className="mt-6 max-w-3xl text-2xl font-semibold leading-snug tracking-tight text-foreground sm:text-[28px]">
         We exist to ensure the React ecosystem thrives for generations to come.
         Through code contributions, community organizing, educational content
         creation, and sustainable funding, we support maintainers, educators,

--- a/src/components/home/mission-statement.tsx
+++ b/src/components/home/mission-statement.tsx
@@ -1,22 +1,23 @@
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
+import { ButtonLink } from "@/components/ui/button";
 
 export function MissionStatement() {
   return (
-    <ScrollReveal animation="fade-up">
-      <section
-        id="mission"
-        className="scroll-mt-32 space-y-6 rounded-3xl border border-border/10 bg-muted/60 p-12"
-      >
-        <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-          Our Mission
-        </h2>
-        <p className="max-w-3xl text-lg leading-relaxed text-foreground/70">
-          We exist to ensure the React ecosystem thrives for generations to come.
-          Through code contributions, community organizing, educational content creation,
-          and sustainable funding, we support maintainers, educators, and community
-          organizers who build the tools millions of developers rely on.
-        </p>
-      </section>
-    </ScrollReveal>
+    <section id="mission" className="scroll-mt-32">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
+        Our Mission
+      </p>
+      <p className="mt-6 max-w-3xl text-2xl font-medium leading-snug tracking-tight text-foreground sm:text-3xl">
+        We exist to ensure the React ecosystem thrives for generations to come.
+        Through code contributions, community organizing, educational content
+        creation, and sustainable funding, we support maintainers, educators,
+        and community organizers who build the tools millions of developers rely
+        on.
+      </p>
+      <div className="mt-8">
+        <ButtonLink href="/about" variant="tertiary" size="md">
+          Learn more →
+        </ButtonLink>
+      </div>
+    </section>
   );
 }

--- a/src/components/home/three-pillars.tsx
+++ b/src/components/home/three-pillars.tsx
@@ -1,115 +1,137 @@
-import { ButtonLink } from "@/components/ui/button";
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
+import type { ReactNode } from "react";
+
+// Scattered "contributor" avatars for the Funding card. Filled dots use semantic
+// accent tints; the rest are empty seats — swap for real avatars when available.
+const FILLED = new Set([1, 4, 7, 10, 14, 17, 21, 24, 28, 31, 34]);
+const TINTS = [
+  "from-primary to-primary/60",
+  "from-success to-success/70",
+  "from-warning to-warning/70",
+];
+
+function AvatarGrid() {
+  return (
+    <div className="grid grid-cols-8 gap-2.5 sm:grid-cols-12">
+      {Array.from({ length: 36 }).map((_, i) =>
+        FILLED.has(i) ? (
+          <div
+            key={i}
+            className={`aspect-square rounded-full bg-gradient-to-br ${TINTS[i % TINTS.length]}`}
+          />
+        ) : (
+          <div
+            key={i}
+            className="aspect-square rounded-full border border-border/60 bg-muted"
+          />
+        ),
+      )}
+    </div>
+  );
+}
+
+function EducationMedia() {
+  return (
+    <div className="relative flex h-44 items-center justify-center overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-muted to-accent">
+      <svg
+        className="h-12 w-12 text-muted-foreground/50"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 14l9-5-9-5-9 5 9 5z M12 14l6.16-3.42A12 12 0 0112 21a12 12 0 01-6.16-10.42L12 14z"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function AccessibilityMedia() {
+  return (
+    <div className="relative flex h-44 items-center justify-center overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-muted to-accent">
+      <svg
+        className="h-14 w-14 text-muted-foreground/50"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="4" r="1.6" fill="currentColor" stroke="none" />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4 8h16M12 8v5m0 0l-3.5 6M12 13l3.5 6"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function PillarCard({
+  label,
+  accentClass,
+  description,
+  media,
+}: {
+  label: string;
+  accentClass: string;
+  description: string;
+  media: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-6 rounded-3xl border border-border/60 bg-card p-8">
+      <div className="space-y-4">
+        <p className={`font-mono text-xs uppercase tracking-[0.18em] ${accentClass}`}>
+          {label}
+        </p>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      {media}
+    </div>
+  );
+}
 
 export function ThreePillars() {
   return (
-    <ScrollReveal animation="scale">
-      <section
-        id="pillars"
-        className="scroll-mt-32 space-y-12 rounded-3xl border border-border/10 bg-muted/60 p-12"
-      >
-        <div className="text-center">
-          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-            Three Pillars of Impact
-          </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-base text-foreground/60">
-            Every contribution supports our three core initiatives
-          </p>
+    <section id="pillars" className="scroll-mt-32 space-y-6">
+      {/* Funding — full width */}
+      <div className="rounded-3xl border border-border/60 bg-card p-8 sm:p-10">
+        <p className="font-mono text-xs uppercase tracking-[0.18em] text-success">
+          Funding
+        </p>
+        <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
+          Direct financial support for the developers maintaining the libraries
+          you depend on every day. Maintainers receive funding through multiple
+          channels including code contributions, sponsorships, and community
+          support.
+        </p>
+        <div className="mt-8">
+          <AvatarGrid />
         </div>
+      </div>
 
-        <div className="grid gap-8 lg:grid-cols-3">
-          <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-400 to-cyan-500">
-              <svg
-                className="h-8 w-8 text-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold text-foreground">
-              Fund Maintainers
-            </h3>
-            <p className="text-sm leading-relaxed text-foreground/70">
-              Direct financial support for the developers maintaining the libraries
-              you depend on every day. Maintainers receive funding through multiple
-              channels including code contributions, sponsorships, and community support.
-            </p>
-            <div className="pt-4">
-              <ButtonLink href="/impact" variant="ghost" size="sm">
-                See Impact →
-              </ButtonLink>
-            </div>
-          </div>
-
-          <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-sky-400 to-indigo-500">
-              <svg
-                className="h-8 w-8 text-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold text-foreground">
-              Education & Resources
-            </h3>
-            <p className="text-sm leading-relaxed text-foreground/70">
-              Supporting tutorials, documentation, workshops, and learning materials
-              that help developers master React and its ecosystem.
-            </p>
-            <div className="pt-4">
-              <ButtonLink href="/impact" variant="ghost" size="sm">
-                Learn More →
-              </ButtonLink>
-            </div>
-          </div>
-
-          <div className="space-y-4 rounded-2xl border border-border/10 bg-background/[0.03] p-8">
-            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-yellow-300 to-orange-500">
-              <svg
-                className="h-8 w-8 text-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold text-foreground">
-              Global Accessibility
-            </h3>
-            <p className="text-sm leading-relaxed text-foreground/70">
-              Ensuring React remains accessible and inclusive for developers worldwide,
-              regardless of location, background, or resources.
-            </p>
-            <div className="pt-4">
-              <ButtonLink href="/impact" variant="ghost" size="sm">
-                Our Commitment →
-              </ButtonLink>
-            </div>
-          </div>
-        </div>
-      </section>
-    </ScrollReveal>
+      {/* Education + Accessibility */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <PillarCard
+          label="Education"
+          accentClass="text-warning"
+          description="Supporting tutorials, documentation, workshops, and learning materials that help developers master React and its ecosystem."
+          media={<EducationMedia />}
+        />
+        <PillarCard
+          label="Accessibility"
+          accentClass="text-primary"
+          description="Ensuring React remains accessible and inclusive for developers worldwide, regardless of location, background, or resources."
+          media={<AccessibilityMedia />}
+        />
+      </div>
+    </section>
   );
 }

--- a/src/components/home/three-pillars.tsx
+++ b/src/components/home/three-pillars.tsx
@@ -1,71 +1,95 @@
 import type { ReactNode } from "react";
 
-// Scattered "contributor" avatars for the Funding card. Filled dots use semantic
-// accent tints; the rest are empty seats — swap for real avatars when available.
-const FILLED = new Set([1, 4, 7, 10, 14, 17, 21, 24, 28, 31, 34]);
-const TINTS = [
-  "from-primary to-primary/60",
-  "from-success to-success/70",
-  "from-warning to-warning/70",
-];
+import { ReactAtom } from "@/components/ui/react-atom";
 
-function AvatarGrid() {
+// Scattered "contributor" avatar cloud for the Funding card. Most seats are empty
+// (muted placeholders); a handful glow with accent tints. Swap the filled dots for
+// real maintainer avatars when available — the scatter/layout is production-ready.
+const CLOUD_COLS = 15;
+const CLOUD_ROWS = 7;
+const CLOUD_TOTAL = CLOUD_COLS * CLOUD_ROWS;
+const CLOUD_FILLED = new Map<number, string>([
+  [3, "from-primary to-primary/60"],
+  [9, "from-success to-success/70"],
+  [16, "from-warning to-warning/70"],
+  [22, "from-primary to-primary/60"],
+  [27, "from-success to-success/70"],
+  [34, "from-warning to-warning/70"],
+  [38, "from-primary to-primary/60"],
+  [45, "from-success to-success/70"],
+  [51, "from-warning to-warning/70"],
+  [58, "from-primary to-primary/60"],
+  [63, "from-success to-success/70"],
+  [70, "from-warning to-warning/70"],
+  [77, "from-primary to-primary/60"],
+  [84, "from-success to-success/70"],
+  [91, "from-warning to-warning/70"],
+]);
+
+function AvatarCloud() {
   return (
-    <div className="grid grid-cols-8 gap-2.5 sm:grid-cols-12">
-      {Array.from({ length: 36 }).map((_, i) =>
-        FILLED.has(i) ? (
-          <div
-            key={i}
-            className={`aspect-square rounded-full bg-gradient-to-br ${TINTS[i % TINTS.length]}`}
-          />
-        ) : (
-          <div
-            key={i}
-            className="aspect-square rounded-full border border-border/60 bg-muted"
-          />
-        ),
-      )}
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-y-0 right-0 hidden w-1/2 overflow-hidden md:block"
+    >
+      <div
+        className="absolute right-6 top-1/2 grid -translate-y-1/2 gap-2.5"
+        style={{ gridTemplateColumns: `repeat(${CLOUD_COLS}, 2rem)` }}
+      >
+        {Array.from({ length: CLOUD_TOTAL }).map((_, i) => {
+          const tint = CLOUD_FILLED.get(i);
+          return tint ? (
+            <div
+              key={i}
+              className={`h-8 w-8 rounded-full bg-gradient-to-br ${tint} shadow-sm`}
+            />
+          ) : (
+            <div
+              key={i}
+              className="h-8 w-8 rounded-full border border-border/60 bg-muted"
+            />
+          );
+        })}
+      </div>
+      {/* Fade the cloud into the card so the title + copy stay legible */}
+      <div className="absolute inset-y-0 left-0 w-2/3 bg-gradient-to-r from-card via-card to-transparent" />
     </div>
   );
 }
 
 function EducationMedia() {
+  // Two overlapping, tilted "learning material" tiles — placeholders for the
+  // tutorial/workshop photography in the design.
   return (
-    <div className="relative flex h-44 items-center justify-center overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-muted to-accent">
-      <svg
-        className="h-12 w-12 text-muted-foreground/50"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 14l9-5-9-5-9 5 9 5z M12 14l6.16-3.42A12 12 0 0112 21a12 12 0 01-6.16-10.42L12 14z"
-        />
-      </svg>
+    <div className="pointer-events-none absolute -bottom-6 left-8 right-8 h-56">
+      <div className="absolute bottom-4 left-2 h-40 w-64 -rotate-[7deg] overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-warning/15 via-muted to-accent shadow-lg" />
+      <div className="absolute bottom-0 left-24 h-40 w-64 rotate-[7deg] overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-muted to-accent shadow-xl">
+        <div className="absolute inset-0 flex items-center justify-center">
+          <ReactAtom className="h-10 w-10 text-muted-foreground/25" strokeWidth={0.8} />
+        </div>
+      </div>
     </div>
   );
 }
 
 function AccessibilityMedia() {
+  // Accessibility mark rising over a "globe" — inclusivity worldwide.
   return (
-    <div className="relative flex h-44 items-center justify-center overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-muted to-accent">
+    <div className="pointer-events-none absolute -bottom-16 left-1/2 h-72 w-72 -translate-x-1/2">
+      <div className="absolute inset-x-0 top-14 mx-auto h-72 w-72 rounded-full bg-gradient-to-b from-primary/25 via-primary/10 to-transparent" />
       <svg
-        className="h-14 w-14 text-muted-foreground/50"
+        className="absolute left-1/2 top-0 h-24 w-24 -translate-x-1/2 text-primary"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
-        strokeWidth={1.5}
+        strokeWidth={1.4}
         aria-hidden="true"
       >
-        <circle cx="12" cy="4" r="1.6" fill="currentColor" stroke="none" />
+        <circle cx="12" cy="4" r="1.7" fill="currentColor" stroke="none" />
         <path
           strokeLinecap="round"
           strokeLinejoin="round"
-          d="M4 8h16M12 8v5m0 0l-3.5 6M12 13l3.5 6"
+          d="M3.5 7.5h17M12 7.5v6m0 0l-3.5 7M12 13.5l3.5 7"
         />
       </svg>
     </div>
@@ -84,15 +108,13 @@ function PillarCard({
   media: ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-6 rounded-3xl border border-border/60 bg-card p-8">
-      <div className="space-y-4">
-        <p className={`font-mono text-xs uppercase tracking-[0.18em] ${accentClass}`}>
-          {label}
-        </p>
-        <p className="text-sm leading-relaxed text-muted-foreground">
-          {description}
-        </p>
-      </div>
+    <div className="relative flex h-[420px] flex-col gap-4 overflow-hidden rounded-[2rem] border border-border/60 bg-card p-8 shadow-[0_14px_44px_0_rgba(0,0,0,0.07)] sm:p-10">
+      <p className={`text-2xl font-semibold tracking-tight ${accentClass}`}>
+        {label}
+      </p>
+      <p className="max-w-sm text-base leading-relaxed text-muted-foreground">
+        {description}
+      </p>
       {media}
     </div>
   );
@@ -100,25 +122,23 @@ function PillarCard({
 
 export function ThreePillars() {
   return (
-    <section id="pillars" className="scroll-mt-32 space-y-6">
-      {/* Funding — full width */}
-      <div className="rounded-3xl border border-border/60 bg-card p-8 sm:p-10">
-        <p className="font-mono text-xs uppercase tracking-[0.18em] text-success">
+    <section id="pillars" className="scroll-mt-32 space-y-5">
+      {/* Funding — full width, avatar cloud */}
+      <div className="relative flex h-[420px] flex-col gap-4 overflow-hidden rounded-[2rem] border border-border/60 bg-card p-8 shadow-[0_14px_44px_0_rgba(0,0,0,0.07)] sm:p-10">
+        <p className="relative z-10 text-2xl font-semibold tracking-tight text-success">
           Funding
         </p>
-        <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        <p className="relative z-10 max-w-sm text-base leading-relaxed text-muted-foreground">
           Direct financial support for the developers maintaining the libraries
           you depend on every day. Maintainers receive funding through multiple
           channels including code contributions, sponsorships, and community
           support.
         </p>
-        <div className="mt-8">
-          <AvatarGrid />
-        </div>
+        <AvatarCloud />
       </div>
 
       {/* Education + Accessibility */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid gap-5 lg:grid-cols-2">
         <PillarCard
           label="Education"
           accentClass="text-warning"

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,22 +1,125 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { ReactAtom } from "@/components/ui/react-atom";
+
+type FooterLink = { href: string; label: string };
+
+const FOOTER_LINKS: FooterLink[] = [
+  { href: "/", label: "Home" },
+  { href: "/updates", label: "Updates" },
+  { href: "/impact", label: "Impact" },
+  { href: "/communities", label: "Communities" },
+];
+
+const SOCIAL_LINKS: { href: string; label: string; icon: ReactNode }[] = [
+  {
+    href: "https://x.com/reactjs",
+    label: "React Foundation on X",
+    icon: (
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    ),
+  },
+  {
+    href: "https://github.com/reactjs",
+    label: "React Foundation on GitHub",
+    icon: (
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23a11.509 11.509 0 013.003-.404c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    ),
+  },
+  {
+    href: "https://www.youtube.com/@React",
+    label: "React Foundation on YouTube",
+    icon: (
+      <path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    ),
+  },
+  {
+    href: "https://www.instagram.com/",
+    label: "React Foundation on Instagram",
+    icon: (
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
+    ),
+  },
+];
 
 export function Footer() {
   return (
-    <footer className="mt-20 border-t border-border/10 py-10 text-sm text-foreground/50">
-      <div className="mx-auto max-w-6xl px-6 sm:px-8 lg:px-12">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <p className="max-w-2xl leading-relaxed">
-            Copyright © The Linux Foundation®. All rights reserved. The Linux Foundation has
-            registered trademarks and uses trademarks. For more information, including terms
-            of use, privacy policy, and trademark usage, please see our{" "}
-            <Link className="underline hover:text-foreground" href="https://www.linuxfoundation.org/legal/policies?__hstc=262006610.e1a66f67cd0c0baa5c7b042e4f9911ce.1768952497248.1771462813100.1771610134177.3&__hssc=262006610.1.1771610134177&__hsfp=360811d5cbd407fc58d506f8b0aa3133">
-              Policies page
+    <footer className="border-t border-border/60 bg-background">
+      <div className="mx-auto max-w-6xl px-6 py-16 sm:px-8 lg:px-12">
+        <div className="flex flex-col gap-12 sm:flex-row sm:justify-between">
+          {/* Brand + socials */}
+          <div className="flex max-w-sm flex-col justify-between gap-10">
+            <Link href="/" className="flex items-center gap-2.5">
+              <ReactAtom className="h-6 w-6 text-foreground" strokeWidth={1.1} />
+              <span className="text-base font-semibold tracking-tight text-foreground">
+                The React Foundation
+              </span>
             </Link>
-            .
-          </p>
-          <div className="flex shrink-0 gap-6">
-            <Link className="transition hover:text-foreground" href="/privacy">Privacy</Link>
-            <Link className="transition hover:text-foreground" href="/terms">Terms</Link>
+
+            <div className="flex items-center gap-5">
+              {SOCIAL_LINKS.map((social) => (
+                <a
+                  key={social.href}
+                  href={social.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={social.label}
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <svg
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    {social.icon}
+                  </svg>
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* Links + legal */}
+          <div className="flex flex-col gap-10 sm:max-w-md">
+            <nav className="flex flex-col gap-3 text-sm">
+              {FOOTER_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Copyright © The Linux Foundation®. All rights reserved. The Linux
+              Foundation has registered trademarks and uses trademarks. For more
+              information, including terms of use, privacy policy, and trademark
+              usage, please see our{" "}
+              <Link
+                className="underline underline-offset-2 hover:text-foreground"
+                href="https://www.linuxfoundation.org/legal/policies"
+              >
+                Policies page
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div className="mt-12 flex flex-col gap-3 border-t border-border/60 pt-6 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>© The React Foundation</p>
+          <div className="flex gap-6">
+            <Link className="transition-colors hover:text-foreground" href="/terms">
+              Terms &amp; conditions
+            </Link>
+            <Link className="transition-colors hover:text-foreground" href="/privacy">
+              Privacy Policy
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useState, useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
-import { RFDS } from "@/components/rfds";
+import { ReactAtom } from "@/components/ui/react-atom";
 import { MobileMenu } from "@/components/layout/mobile-menu";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { ThemeToggleWrapper } from "@/components/ui/theme-toggle-wrapper";
+
+type NavLink = { href: string; label: string };
+
+const FOUNDATION_LINKS: NavLink[] = [
+  { href: "/updates", label: "News" },
+  { href: "/about", label: "About" },
+  { href: "/impact", label: "Impact" },
+  { href: "/communities", label: "Communities" },
+];
+
+const STORE_LINKS: NavLink[] = [
+  { href: "/store#featured", label: "Collections" },
+  { href: "/store#drops", label: "Limited Drops" },
+  { href: "/impact", label: "Impact" },
+];
 
 export function Header() {
   const pathname = usePathname();
@@ -28,7 +42,7 @@ export function Header() {
       }
 
       try {
-        const response = await fetch('/api/admin/check');
+        const response = await fetch("/api/admin/check");
         if (response.ok) {
           const data = await response.json();
           setIsAdmin(data.isAdmin);
@@ -36,7 +50,7 @@ export function Header() {
           setIsAdmin(false);
         }
       } catch (error) {
-        console.error('Failed to check admin status:', error);
+        console.error("Failed to check admin status:", error);
         setIsAdmin(false);
       }
     };
@@ -44,76 +58,53 @@ export function Header() {
     checkAdminStatus();
   }, [session?.user?.email]);
 
-  return (
-    <header className="fixed left-0 right-0 top-0 z-50 bg-background/95 shadow-lg shadow-black/5 backdrop-blur-xl supports-[backdrop-filter]:bg-background/80">
-      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4 sm:px-8 lg:px-12">
-        {/* Logo */}
-        <div className="flex items-center gap-3">
-          <div className="relative h-10 w-10 overflow-hidden">
-            <Link href="/">
-              <Image
-                src="/react-logo.svg"
-                alt="React Foundation logo"
-                fill
-                sizes="40px"
-                className="object-contain p-1.5"
-                priority
-              />
-            </Link>
-          </div>
-          <div>
-            <Link href="/">
-              <p className="text-sm uppercase tracking-[0.25em] text-muted-foreground">
-                React Foundation
-              </p>
-              <p className="text-base font-medium text-foreground">
-                {isStorePage ? "Official Store" : "Supporting the Ecosystem"}
-              </p>
-            </Link>
-          </div>
-        </div>
+  const links = isStorePage ? STORE_LINKS : FOUNDATION_LINKS;
 
-        {/* Desktop Navigation (hidden on mobile) */}
-        <div className={`hidden items-center gap-4 text-sm text-muted-foreground md:flex transition ${isComingSoonPage ? 'blur-sm pointer-events-none' : ''}`}>
-          <nav className="flex items-center gap-6">
-            {isStorePage ? (
-              // Store navigation
-              <>
-                <Link className="transition hover:text-foreground" href="/store#featured">
-                  Collections
-                </Link>
-                <Link className="transition hover:text-foreground" href="/store#drops">
-                  Limited Drops
-                </Link>
-                <Link className="transition hover:text-foreground" href="/impact">
-                  Impact
-                </Link>
-              </>
-            ) : (
-              // Foundation navigation
-              <>
-                <Link className="transition hover:text-foreground" href="/about">
-                  About
-                </Link>
-                <Link className="transition hover:text-foreground" href="/updates">
-                  Updates
-                </Link>
-                <Link className="transition hover:text-foreground" href="/impact">
-                  Impact
-                </Link>
-                <Link className="transition hover:text-foreground" href="/communities">
-                  Communities
-                </Link>
-                {isAdmin && (
-                  <Link
-                    className="transition hover:text-foreground text-destructive font-medium"
-                    href="/admin"
-                    title="Admin Panel"
-                  >
-                    ⚙️
-                  </Link>
-                )}
-              </>
+  const isActive = (href: string) => {
+    const base = href.split("#")[0];
+    if (!base || base === "/") return false;
+    return pathname === base || pathname?.startsWith(`${base}/`);
+  };
+
+  return (
+    <header className="fixed left-0 right-0 top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/70">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4 sm:px-8 lg:px-12">
+        {/* Brand */}
+        <Link href="/" className="flex items-center gap-2.5">
+          <ReactAtom className="h-6 w-6 text-foreground" strokeWidth={1.1} />
+          <span className="text-base font-semibold tracking-tight text-foreground">
+            {isStorePage ? "The React Foundation Store" : "The React Foundation"}
+          </span>
+        </Link>
+
+        {/* Desktop Navigation */}
+        <div
+          className={`hidden items-center gap-8 md:flex ${
+            isComingSoonPage ? "pointer-events-none blur-sm" : ""
+          }`}
+        >
+          <nav className="flex items-center gap-8 text-sm">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`transition-colors hover:text-foreground ${
+                  isActive(link.href)
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+            {isAdmin && (
+              <Link
+                className="font-medium text-destructive transition-colors hover:text-destructive/80"
+                href="/admin"
+                title="Admin Panel"
+              >
+                Admin
+              </Link>
             )}
           </nav>
 
@@ -139,26 +130,30 @@ export function Header() {
             </Button>
           )}
 
-          {/* Theme Toggle */}
-          <ThemeToggleWrapper />
+          <div className="flex items-center gap-3">
+            <ThemeToggleWrapper />
 
-          {/* Profile Icon or Sign In */}
-          {session?.user ? (
-            <UserAvatar
-              user={session.user}
-              size={40}
-              href="/profile"
-              className="transition hover:border-primary/50 hover:shadow-lg hover:shadow-primary/20"
-            />
-          ) : (
-            <RFDS.ButtonLink href="/api/auth/signin" size="sm">
-              Sign in
-            </RFDS.ButtonLink>
-          )}
+            {session?.user ? (
+              <UserAvatar
+                user={session.user}
+                size={36}
+                href="/profile"
+                className="transition hover:border-primary/50"
+              />
+            ) : (
+              <Link
+                href="/api/auth/signin"
+                className="rounded-full border border-border bg-background px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              >
+                Sign in
+              </Link>
+            )}
+          </div>
         </div>
 
-        {/* Mobile Menu (shows on mobile only) */}
+        {/* Mobile controls */}
         <div className="flex items-center gap-2 md:hidden">
+          <ThemeToggleWrapper />
           {isStorePage && (
             <Button variant="glass" size="sm" className="relative px-3" type="button">
               <svg

--- a/src/components/layout/mobile-menu.tsx
+++ b/src/components/layout/mobile-menu.tsx
@@ -54,8 +54,8 @@ export function MobileMenu({ session }: MobileMenuProps) {
         { href: "/impact", label: "Impact" },
       ]
     : [
+        { href: "/updates", label: "News" },
         { href: "/about", label: "About" },
-        { href: "/updates", label: "Updates" },
         { href: "/impact", label: "Impact" },
         { href: "/communities", label: "Communities" },
       ];

--- a/src/components/ui/react-atom.tsx
+++ b/src/components/ui/react-atom.tsx
@@ -1,0 +1,31 @@
+import type { SVGProps } from "react";
+
+type ReactAtomProps = SVGProps<SVGSVGElement> & {
+  /** Stroke width in viewBox units (24-unit box). Lower values read thinner. */
+  strokeWidth?: number;
+};
+
+/**
+ * The React atom mark, drawn as a monochrome outline that inherits `currentColor`.
+ * Keeping it as an inline SVG (rather than the filled brand asset) lets it adapt to
+ * light/dark themes and sit quietly in the neutral, Expo-aligned layout.
+ */
+export function ReactAtom({ strokeWidth = 1, ...props }: ReactAtomProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="1.75" fill="currentColor" stroke="none" />
+      <g strokeWidth={strokeWidth}>
+        <ellipse cx="12" cy="12" rx="11" ry="4.2" />
+        <ellipse cx="12" cy="12" rx="11" ry="4.2" transform="rotate(60 12 12)" />
+        <ellipse cx="12" cy="12" rx="11" ry="4.2" transform="rotate(120 12 12)" />
+      </g>
+    </svg>
+  );
+}

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -28,6 +28,7 @@ export interface Community {
   linkedin_url?: string;
 
   // Details
+  cover_image?: string; // Optional cover/banner image URL for list + detail cards
   description: string;
   member_count: number;
   typical_attendance: number;

--- a/todos/react-foundation-homepage-sybdk5-todo.md
+++ b/todos/react-foundation-homepage-sybdk5-todo.md
@@ -1,0 +1,53 @@
+# todos: react-foundation-homepage-sybdk5
+
+Redesign of the marketing pages toward a neutral, primitive, Expo.dev-aligned look
+(neutral gray surfaces, one blue accent, hairline borders, restrained shadows,
+generous spacing, mono "eyebrow" section labels). Layout follows the provided
+Figma screenshots; styling aligns with the attached Expo design system.
+
+## Completed — Homepage (`/`) + shared chrome
+
+- [x] `src/components/ui/react-atom.tsx` — theme-aware `currentColor` outline React atom
+      (header, hero, footer). Replaces the filled cyan brand asset for the neutral look.
+- [x] Header (`src/components/layout/header.tsx`) — single-line "The React Foundation"
+      wordmark + atom, nav `News · About · Impact · Communities` with active states,
+      theme toggle + hairline "Sign in" pill. Store/admin/auth logic preserved.
+- [x] Mobile menu (`src/components/layout/mobile-menu.tsx`) — nav label `Updates → News`,
+      reordered to match header.
+- [x] Footer (`src/components/layout/footer.tsx`) — brand, link column
+      (Home/Updates/Impact/Communities), social icons (X/GitHub/YouTube/Instagram),
+      Linux Foundation copyright, bottom bar. Global (improves every page).
+- [x] Hero (`foundation-hero.tsx`) — centered atom + heading + subhead + single
+      "Get involved" CTA on a subtle neutral backdrop.
+- [x] Community gallery (`community-gallery.tsx`) — tilted "moments" band. **Placeholder
+      tiles** (gradient + label); swap for real event photos.
+- [x] Members strip (`members-strip.tsx`) — "Meet our members" + founding-member logos,
+      theme-adaptive monochrome (gray on light, white on dark).
+- [x] Mission (`mission-statement.tsx`) — mono eyebrow + large statement + "Learn more".
+- [x] Three pillars (`three-pillars.tsx`) — full-width Funding card w/ contributor-avatar
+      grid, plus Education + Accessibility cards. Categorical accents: success/warning/primary.
+- [x] Become a Contributor (`become-contributor.tsx`) — 2×2 grid, teal "Become a Member" card.
+- [x] Join the Movement (`join-movement-cta.tsx`) — centered CTA.
+- [x] Page (`src/app/page.tsx`) — composes the above; neutral top backdrop; generous rhythm.
+- [x] `globals.css` — added missing `--warning` token (was referenced across the app but
+      undefined, so `bg-warning`/`text-warning` were no-ops). Additive; `--warning-foreground`
+      intentionally left undefined to avoid regressing admin usages.
+- [x] Verified: `tsc --noEmit` clean; changed files lint-clean; light+dark, desktop+mobile
+      screenshots reviewed.
+
+## Deferred (need assets / decisions)
+
+- [ ] Real community event photos for the gallery (currently placeholder tiles).
+- [ ] Light-variant logos for **Callstack** and **Software Mansion** — their SVGs are
+      white-only (built for dark bg), so they're excluded from the light members strip.
+- [ ] Optional: retune `--primary` toward the Figma teal / Expo `blue-10` if the exact
+      brand blue matters (kept the existing semantic `primary` = sky-500 for now).
+- [ ] Optional: full migration of global tokens to the Radix scale from the Expo spec
+      (kept blast radius small by reusing existing neutral tokens + component styling).
+
+## Next steps (other pages from the screenshots, same neutral direction)
+
+- [ ] About (`/about`) — hero, Executive Director message, Our Mission cards, How it works,
+      Become a Contributor, "Ready to Make an Impact?" CTA.
+- [ ] Communities (`/communities`) — "Find Your React Community" hero + stats + map + list.
+- [ ] News/Updates (`/updates`) — "Latest news" + Follow/Subscribe + article cards.

--- a/todos/react-foundation-homepage-sybdk5-todo.md
+++ b/todos/react-foundation-homepage-sybdk5-todo.md
@@ -45,9 +45,25 @@ Figma screenshots; styling aligns with the attached Expo design system.
 - [ ] Optional: full migration of global tokens to the Radix scale from the Expo spec
       (kept blast radius small by reusing existing neutral tokens + component styling).
 
-## Next steps (other pages from the screenshots, same neutral direction)
+## Completed — About / News / Communities (neutral redesign)
 
-- [ ] About (`/about`) — hero, Executive Director message, Our Mission cards, How it works,
-      Become a Contributor, "Ready to Make an Impact?" CTA.
-- [ ] Communities (`/communities`) — "Find Your React Community" hero + stats + map + list.
-- [ ] News/Updates (`/updates`) — "Latest news" + Follow/Subscribe + article cards.
+- [x] About (`/about`) — single-column neutral layout: hero, Executive Director message
+      (restyled `executive-message.tsx`), Our Mission (3 cards), How it works (4 numbered
+      steps), Governance (Board/TSC — kept so those sub-pages keep a nav entry), Become a
+      Contributor, "Ready to Make an Impact?" CTA. Dropped the ToC sidebar, the vibrant
+      gradient, and the standalone Ecosystem/Founding-members sections (represented elsewhere).
+- [x] News/Updates (`/updates`) — "Latest news" + Follow/Subscribe pills, neutral article
+      cards (date, title, description, author avatar), View Archive. Neutralized the shared
+      `updates/layout.tsx` gradient (also affects article detail pages).
+- [x] Communities (`/communities`) — neutral hero, inline stats, map in a rounded card with a
+      CoIS tier legend, "All communities" + "Start a community", horizontal filter bar
+      (Search/Status/Event type/Tier), restyled community cards. Preserved all SWR/URL-filter
+      logic; removed a stray `console.log`. Note: event-type filter is now single-select
+      (matches the mock's single dropdown) rather than the previous multi-select.
+
+## Notes / follow-ups for these pages
+
+- News mock showed 3 articles; the repo's `content/updates` currently has fewer — the card
+  layout is what changed, content is unchanged.
+- Community cards use an initials placeholder (no logo field on the `Community` type).
+- Map tiles + live community/stats data need network + Redis; verified layout with sample data.


### PR DESCRIPTION
Brings the marketing pages in line with the Figma redesign, using the project's semantic color tokens (no raw hex) and covering mobile.

## Homepage
Restored the Figma's visual language: large colored card titles (Funding/Education/Accessibility), plain-blue "Our Mission" label, scattered avatar cloud, larger tilted gallery, larger CTA.

## About
Numbered-circle "How it works" timeline; tall icon-top/text-bottom mission cards; refined executive-message card. Kept the Governance section (only entry point to the Board/TSC subpages) and restyled it to fit.

## News (list + detail)
List cards match the Figma and use the live MDX content. Detail page: removed `prose-invert` + hardcoded cyan (was white-on-white in light mode) so theme-aware prose drives light/dark; fixed an off-by-one post date.

## Communities
Restyled map markers only (clean teardrop pins, refined tier palette, synced legend); responsive map height. List cards now surface a cover image (new optional `cover_image` field) with a gradient-placeholder fallback.

Verified with `tsc --noEmit`, lint (clean on touched files), and light/dark + mobile screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)