### PR TITLE
Fix: keep non-existent /docs links out of the content map

### DIFF
--- a/src/lib/ingest/content-map.test.ts
+++ b/src/lib/ingest/content-map.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateContentMap } from './content-map';
+import type { ContentMap, ContentSection, RawRecord } from './types';
+
+function makeRecord(partial: Partial<RawRecord>): RawRecord {
+  return {
+    id: 'id',
+    type: 'page',
+    title: 'Title',
+    url: '/',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    body: 'body',
+    ...partial,
+  };
+}
+
+function collectUrls(map: ContentMap): string[] {
+  const urls: string[] = [];
+  const walk = (sections: ContentSection[]) => {
+    for (const section of sections) {
+      if (section.url) {
+        urls.push(section.url);
+      }
+      if (section.children) {
+        walk(section.children);
+      }
+    }
+  };
+  walk(map.sections);
+  return urls;
+}
+
+describe('generateContentMap', () => {
+  it('does not emit /docs urls for public-context knowledge-base entries', () => {
+    const map = generateContentMap([
+      makeRecord({ id: 'ris', type: 'page', title: 'RIS System', url: '/docs/foundation/ris-system' }),
+      makeRecord({ id: 'faq', type: 'page', title: 'FAQ', url: '/docs/faq' }),
+      makeRecord({ id: 'about', type: 'page', title: 'About', url: '/about' }),
+      makeRecord({ id: 'lib', type: 'library', title: 'React', url: '/libraries' }),
+    ]);
+
+    const docsUrls = collectUrls(map).filter((url) => url.startsWith('/docs'));
+    expect(docsUrls).toEqual([]);
+  });
+
+  it('keeps real pages that were grouped alongside knowledge-base docs', () => {
+    const map = generateContentMap([
+      makeRecord({ id: 'ris', type: 'page', title: 'RIS System', url: '/docs/foundation/ris-system' }),
+      makeRecord({ id: 'about', type: 'page', title: 'About', url: '/about' }),
+    ]);
+
+    expect(collectUrls(map)).toContain('/about');
+  });
+
+  it('does not give the page section a base url that is not a real route', () => {
+    const map = generateContentMap([
+      makeRecord({ id: 'about', type: 'page', title: 'About', url: '/about' }),
+    ]);
+
+    const documentation = map.sections.find((section) => section.title === 'Documentation');
+    expect(documentation).toBeDefined();
+    expect(documentation?.url).toBeUndefined();
+  });
+
+  it('drops a section entirely when all of its entries were knowledge-base docs', () => {
+    const map = generateContentMap([
+      makeRecord({ id: 'ris', type: 'page', title: 'RIS System', url: '/docs/foundation/ris-system' }),
+      makeRecord({ id: 'lib', type: 'library', title: 'React', url: '/libraries' }),
+    ]);
+
+    expect(map.sections.find((section) => section.title === 'Documentation')).toBeUndefined();
+    expect(map.sections.find((section) => section.title === 'Tracked Libraries')).toBeDefined();
+  });
+});

--- a/src/lib/ingest/content-map.ts
+++ b/src/lib/ingest/content-map.ts
@@ -63,41 +63,59 @@ function createSection(type: string, records: RawRecord[]): ContentSection | nul
     return null;
   }
 
-  // Determine section title and base URL
-  const sectionConfig: Record<string, { title: string; url: string }> = {
-    'page': { title: 'Documentation', url: '/docs' },
-    'faq': { title: 'FAQ', url: '/faq' },
+  // Determine section title and base URL. A section only gets a `url` when its
+  // base path is a real public route. `page`, `faq` and `educator` have no
+  // matching route (there is no /docs, /faq or /educators page), so they are
+  // containers without a clickable url.
+  const sectionConfig: Record<string, { title: string; url?: string }> = {
+    'page': { title: 'Documentation' },
+    'faq': { title: 'FAQ' },
     'library': { title: 'Tracked Libraries', url: '/libraries' },
     'community': { title: 'Communities', url: '/communities' },
-    'educator': { title: 'Educators', url: '/educators' },
+    'educator': { title: 'Educators' },
     'organizer': { title: 'Community Organizers', url: '/communities' },
   };
 
   const config = sectionConfig[type] || { title: type, url: `/${type}` };
 
-  // Create child sections for each record
-  const children: ContentSection[] = records.map(record => {
-    const child: ContentSection = {
-      title: record.title,
-      url: record.url,
-    };
+  // Files under public-context/ are the chatbot knowledge base (see
+  // public-context/README.md). The MDX loader gives them a synthetic /docs/*
+  // url, but no /docs route exists, so those links 404 in production. Keep them
+  // out of the navigation map. They remain in the search index untouched.
+  const children: ContentSection[] = records
+    .filter(record => !record.url.startsWith('/docs'))
+    .map(record => {
+      const child: ContentSection = {
+        title: record.title,
+        url: record.url,
+      };
 
-    // Add anchors if available
-    if (record.anchors && record.anchors.length > 0) {
-      child.anchors = record.anchors;
-    }
+      // Add anchors if available
+      if (record.anchors && record.anchors.length > 0) {
+        child.anchors = record.anchors;
+      }
 
-    return child;
-  });
+      return child;
+    });
+
+  // A section whose entries were all knowledge-base docs has nothing to link to.
+  if (children.length === 0) {
+    return null;
+  }
 
   // Sort children alphabetically
   children.sort((a, b) => a.title.localeCompare(b.title));
 
-  return {
+  const section: ContentSection = {
     title: config.title,
-    url: config.url,
     children,
   };
+
+  if (config.url) {
+    section.url = config.url;
+  }
+
+  return section;
 }
 
 /**

--- a/src/lib/ingest/types.ts
+++ b/src/lib/ingest/types.ts
@@ -58,7 +58,7 @@ export interface ContentMap {
 
 export interface ContentSection {
   title: string;
-  url: string;
+  url?: string; // Omitted for container sections that have no landing route of their own
   children?: ContentSection[];
   anchors?: Array<{ text: string; anchor: string }>;
 }


### PR DESCRIPTION
﻿## Summary

The public content map at `/api/content-map` advertised 13 `/docs/*` URLs that all return HTTP 404 in production. This endpoint feeds the chat assistant, which is told to link users to pages, so the assistant could hand visitors links that lead nowhere. This PR keeps those non-existent `/docs` links out of the navigation map. The content stays in the chatbot search index.

---

## Linked Issue or Exception

Closes #101

---

## Root Cause (for bugs)

Files under `public-context/` are the chatbot knowledge base (see `public-context/README.md`). The MDX loader gives every such file a synthetic `/docs/*` URL (`src/lib/ingest/loaders/mdx.ts:53-55`), but there is no `/docs` route in the app, so these URLs 404.

`src/lib/ingest/content-map.ts` then groups all `type: 'page'` records into a "Documentation" section with a hardcoded base URL `/docs`. Real site pages (`/`, `/about`, `/scoring`) share that same `type`, so the section mixed valid pages with the dead `/docs` entries, and the section's own `/docs` base URL is dead too. Result: 14 dead URLs in the live map (the `/docs` parent plus 13 children).

---

## Solution

`createSection` no longer assigns a base URL to sections whose base path is not a real route (`page` -> `/docs`, `faq` -> `/faq`, `educator` -> `/educators` all had no page). Those become container sections without a clickable `url`. It also drops child entries whose URL starts with `/docs`, and returns no section when all of its entries were knowledge-base docs.

`ContentSection.url` is made optional to allow container sections that have no landing route of their own.

This is direction A from the issue: keep `public-context/` as chatbot-only knowledge. The search index is untouched (`upsertRecords` and `generateContentMap` are separate passes over the same records in `src/app/api/ingest/full/route.ts`), so retrieval still finds this content. Making `/docs` a real public section would be a separate, larger change.

---

## Scope

- [x] This PR has a single concern
- [x] Refactors are directly required for this change
- [x] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Added or updated tests for the changed behavior
- [x] Confirmed the test fails without the fix, when practical
- [x] Verified tests pass with the fix
- [x] Regression tested the original scenario
- [ ] Manually verified UI behavior if applicable

New unit test `src/lib/ingest/content-map.test.ts` covers:

- the map emits no `/docs` URL
- real pages grouped alongside knowledge-base docs are kept
- the "Documentation" section has no dead base URL
- a section is dropped when all of its entries were knowledge-base docs

Local run (a fork PR may not trigger CI, so commands are listed):

- `npx vitest run --project unit src/lib/ingest/content-map.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/lib/ingest/content-map.ts src/lib/ingest/types.ts src/lib/ingest/content-map.test.ts`

---

## Screenshots (if UI)

Not a UI change.

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---

## Notes for Reviewers

The fix scopes to navigation only; the search index behavior is unchanged. If you would rather add a real `/docs` route that renders `public-context/` (direction B in the issue), this PR is a safe interim step that stops the 404s in the meantime.

