### PR TITLE
Fix: add missing tracked libraries to the chatbot knowledge base

### DIFF
--- a/src/lib/ingest/loaders/libraries.ts
+++ b/src/lib/ingest/loaders/libraries.ts
@@ -42,12 +42,13 @@ export class LibrariesLoader implements ContentLoader {
     { repo: 'pmndrs/valtio', name: 'Valtio', category: 'State Management', tier: 'Tier 2' },
     { repo: 'statelyai/xstate', name: 'XState', category: 'State Management', tier: 'Tier 2' },
 
-    // Data Fetching (5 repositories)
+    // Data Fetching (6 repositories)
     { repo: 'TanStack/query', name: 'TanStack Query', category: 'Data Fetching', tier: 'Tier 1' },
     { repo: 'vercel/swr', name: 'SWR', category: 'Data Fetching', tier: 'Tier 1' },
     { repo: 'apollographql/apollo-client', name: 'Apollo Client', category: 'Data Fetching', tier: 'Tier 1' },
     { repo: 'trpc/trpc', name: 'tRPC', category: 'Data Fetching', tier: 'Tier 2' },
     { repo: 'urql-graphql/urql', name: 'urql', category: 'Data Fetching', tier: 'Tier 2' },
+    { repo: 'invertase/react-native-firebase', name: 'React Native Firebase', category: 'Data Fetching', tier: 'Tier 2' },
 
     // Routing (3 repositories)
     { repo: 'remix-run/react-router', name: 'React Router', category: 'Routing', tier: 'Tier 1' },
@@ -75,8 +76,9 @@ export class LibrariesLoader implements ContentLoader {
     { repo: 'microsoft/playwright', name: 'Playwright', category: 'Testing', tier: 'Tier 1' },
     { repo: 'testing-library/react-hooks-testing-library', name: 'React Hooks Testing Library', category: 'Testing', tier: 'Tier 2' },
 
-    // UI/Component Libraries (6 repositories)
+    // UI/Component Libraries (7 repositories)
     { repo: 'radix-ui/primitives', name: 'Radix UI', category: 'UI Libraries', tier: 'Tier 1' },
+    { repo: 'ant-design/ant-design', name: 'Ant Design', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'tailwindlabs/headlessui', name: 'Headless UI', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'mui/material-ui', name: 'Material-UI', category: 'UI Libraries', tier: 'Tier 1' },
     { repo: 'adobe/react-spectrum', name: 'React Spectrum', category: 'UI Libraries', tier: 'Tier 2' },
@@ -98,10 +100,12 @@ export class LibrariesLoader implements ContentLoader {
     // Data Tables (1 repository)
     { repo: 'TanStack/table', name: 'TanStack Table', category: 'Data Tables', tier: 'Tier 1' },
 
-    // Styling (3 repositories)
+    // Styling (5 repositories)
     { repo: 'styled-components/styled-components', name: 'styled-components', category: 'Styling', tier: 'Tier 1' },
     { repo: 'emotion-js/emotion', name: 'Emotion', category: 'Styling', tier: 'Tier 1' },
+    { repo: 'tailwindlabs/tailwindcss', name: 'Tailwind CSS', category: 'Styling', tier: 'Tier 1' },
     { repo: 'facebook/stylex', name: 'StyleX', category: 'Styling', tier: 'Tier 2' },
+    { repo: 'marklawlor/nativewind', name: 'NativeWind', category: 'Styling', tier: 'Tier 2' },
   ];
 
   async load(): Promise<RawRecord[]> {

--- a/src/lib/maintainer-tiers.test.ts
+++ b/src/lib/maintainer-tiers.test.ts
@@ -34,6 +34,18 @@ describe('ecosystemLibraries', () => {
     expect(new Set(repositoryKeys).size).toBe(repositoryKeys.length);
   });
 
+  it('exposes every tracked library to the chatbot knowledge base', async () => {
+    const loader = new LibrariesLoader();
+    const records = await loader.load();
+    const loadedIds = new Set(records.map((record) => record.id));
+
+    const missing = ecosystemLibraries
+      .filter((library) => !loadedIds.has(`library-${library.owner}-${library.name}`.toLowerCase()))
+      .map((library) => `${library.owner}/${library.name}`);
+
+    expect(missing).toEqual([]);
+  });
+
   it('maps requested repositories to their primary npm packages', () => {
     expect(NPMCollector.getPackageName('ant-design', 'ant-design')).toBe('antd');
     expect(NPMCollector.getPackageName('invertase', 'react-native-firebase')).toBe(


### PR DESCRIPTION
﻿## Summary

Adds the four tracked libraries that were missing from the chatbot knowledge base, and adds a regression test so the two lists cannot drift apart again.

`ecosystemLibraries` has 61 repositories, `LibrariesLoader` had 57. Ant Design, Tailwind CSS, NativeWind and React Native Firebase were tracked and advertised by the site but had no grounding content for the assistant, and did not appear in `/api/content-map`.

---

## Linked Issue or Exception

Closes #103

---

## Root Cause (for bugs)

PR #52 ("Fix: add requested ecosystem libraries (closes #42, closes #44)") updated `src/lib/maintainer-tiers.ts`, `src/lib/library-icons.tsx` and `src/lib/ris/collectors/npm-collector.ts`, but not `src/lib/ingest/loaders/libraries.ts`. Issues #42 and #44 were closed while only part of the pipeline was updated.

Nothing enforced that the two lists match, so the gap was invisible. The existing tests show the same shape: Docusaurus, StyleX and React Strict DOM are asserted against `LibrariesLoader`, but the Ant Design and React Native Firebase assertions only cover `ecosystemLibraries` and `NPMCollector`.

---

## Solution

Two changes.

1. `src/lib/ingest/loaders/libraries.ts` — add the four missing entries in their existing category sections, using the same names as `libraryDisplayNames` and the same tier as `ecosystemLibraries`:

| repo | name | category | tier |
|---|---|---|---|
| `ant-design/ant-design` | Ant Design | UI Libraries | Tier 1 |
| `invertase/react-native-firebase` | React Native Firebase | Data Fetching | Tier 2 |
| `tailwindlabs/tailwindcss` | Tailwind CSS | Styling | Tier 1 |
| `marklawlor/nativewind` | NativeWind | Styling | Tier 2 |

Section count comments updated accordingly.

2. `src/lib/maintainer-tiers.test.ts` — add an invariant test asserting that every `ecosystemLibraries` entry is exposed by the loader. This is the durable part: adding a library to `ecosystemLibraries` without adding it to the loader now fails the suite, instead of silently shipping a gap.

Chose the invariant over four more per-library assertions because the per-library pattern is what let this slip in the first place.

`PROBE_REPOS` is intentionally untouched. It is a separate curated sample (42 repos, "10k+ stars, actively maintained, representative"), not a mirror of the tracked list.

---

## Scope

- [x] This PR has a single concern
- [x] Refactors are directly required for this change
- [x] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Added or updated tests for the changed behavior
- [x] Confirmed the test fails without the fix, when practical
- [x] Verified tests pass with the fix
- [x] Regression tested the original scenario
- [ ] Manually verified UI behavior if applicable — no UI change

Specific scenarios tested:

With the new test but before the data fix, the suite fails and names exactly the four gaps:

```
- []
+ [
+   "invertase/react-native-firebase",
+   "ant-design/ant-design",
+   "tailwindlabs/tailwindcss",
+   "marklawlor/nativewind",
+ ]
```

After the data fix:

```
npx vitest run --project unit src/lib/maintainer-tiers.test.ts   # 7 passed
npx vitest run --project unit                                    # 27 passed (10 files)
npx tsc --noEmit                                                 # clean
npx eslint src/lib/ingest/loaders/libraries.ts src/lib/maintainer-tiers.test.ts   # clean
```

Verified against production: `/api/content-map` currently returns 54 entries under "Tracked Libraries" with none of these four present.

---

## Screenshots (if UI)

Not applicable — data and test only.

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] Tests included and passing
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [x] CI passing

---

## Notes for Reviewers

Two things worth a look.

PRs #91, #93 and #97 also append to `ingest/loaders/libraries.ts`. This PR touches the UI Libraries, Data Fetching and Styling sections, so a conflict is only likely on the section count comments. Happy to rebase in whatever order suits the merge queue.

Category mapping for React Native Firebase: `ecosystemLibraries` has it as `data`, and the loader's nearest existing category is `Data Fetching`. Say the word if you would rather it sat under Core React & React Native.

