### PR TITLE
fix: update 'Contribute to Repos' link to foundation repositories page

### DIFF
--- a/src/components/home/become-contributor.tsx
+++ b/src/components/home/become-contributor.tsx
@@ -18,9 +18,8 @@ const contributorData: {
     description:
       'Submit code, RFCs, proposals, documentation, or bug reports to React and the tracked ecosystem repositories. Your contributions directly improve the tools millions of developers use.',
     primaryAction: {
-      href: 'https://github.com/facebook/react',
-      label: 'Browse React repositories',
-      external: true,
+      href: '/libraries',
+      label: 'Browse tracked repositories',
     },
     secondaryAction: {
       href: 'https://github.com/reactjs/rfcs',


### PR DESCRIPTION
The 'Browse React repositories' button in the BecomeContributor section was linking directly to `https://github.com/facebook/react`, which is confusing since it takes users to a single repo rather than a listing of all foundation-tracked repos.

This PR updates the link to `/libraries` — the existing internal page that lists all tracked ecosystem repositories — and updates the button label to 'Browse tracked repositories' to match the new destination.

Co-authored-by: v0 <it+v0agent@vercel.com>