### PR TITLE
Move HomePillars above HomeMission on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,8 +55,8 @@ export default function FoundationHome() {
           <FoundingMembers />
         </Section>
 
-        <HomeMission />
         <HomePillars />
+        <HomeMission />
         <Section className="pb-20 sm:pb-28" measure="standard">
           <BecomeContributor />
         </Section>


### PR DESCRIPTION
Reorders the homepage sections so the three pillar items (01 Independent stewardship, 02 Sustainable support, 03 A connected community) appear before the 'Our mission' section, per ncor-8149's feedback.

**Change:**
- In `src/app/page.tsx`, swapped `<HomePillars />` and `<HomeMission />` so pillars render first.