### PR TITLE
Remove eyebrow labels from Summit page

### DIFF
--- a/public/summit-2026.ics
+++ b/public/summit-2026.ics
@@ -1,0 +1,17 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//React Foundation//Summit 2026//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+UID:summit-2026@react.foundation
+DTSTAMP:20260805T000000Z
+DTSTART;VALUE=DATE:20261110
+DTEND;VALUE=DATE:20261113
+SUMMARY:React Foundation Summit 2026
+LOCATION:London\, United Kingdom
+DESCRIPTION:React Foundation Summit 2026. Days 1 and 2 are for summit participants; Day 3 is reserved for the React Foundation Board. Venue and detailed timings to be confirmed.
+URL:https://react.foundation/summit
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR

--- a/public/summit-2026.ics
+++ b/public/summit-2026.ics
@@ -8,9 +8,8 @@ UID:summit-2026@react.foundation
 DTSTAMP:20260805T000000Z
 DTSTART;VALUE=DATE:20261110
 DTEND;VALUE=DATE:20261113
-SUMMARY:React Foundation Summit 2026
+SUMMARY:React Foundation Contributors Summit 2026
 LOCATION:London\, United Kingdom
-DESCRIPTION:React Foundation Summit 2026. Days 1 and 2 are for summit participants; Day 3 is reserved for the React Foundation Board. Venue and detailed timings to be confirmed.
 URL:https://react.foundation/summit
 STATUS:CONFIRMED
 END:VEVENT

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,6 +32,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     buildEntry(baseUrl, '/about/board-of-directors', 'monthly', 0.7),
     buildEntry(baseUrl, '/about/technical-steering-committee', 'monthly', 0.7),
     buildEntry(baseUrl, '/impact', 'weekly', 0.9),
+    buildEntry(baseUrl, '/summit', 'monthly', 0.9),
     buildEntry(baseUrl, '/authors', 'weekly', 0.8),
     buildEntry(baseUrl, '/updates', 'weekly', 0.8),
     buildEntry(baseUrl, '/libraries', 'weekly', 0.8),

--- a/src/app/summit/leaflet.css
+++ b/src/app/summit/leaflet.css
@@ -1,0 +1,40 @@
+@import "leaflet/dist/leaflet.css";
+
+.summit-map .leaflet-container {
+  background: hsl(var(--muted));
+  font-family: var(--font-geist-sans), sans-serif;
+}
+
+.summit-map .leaflet-control-zoom {
+  overflow: hidden;
+  border: 1px solid hsl(var(--border)) !important;
+  border-radius: 0.75rem !important;
+  box-shadow: var(--foundation-shadow-card) !important;
+}
+
+.summit-map .leaflet-control-zoom a {
+  border: 0 !important;
+  background: hsl(var(--background) / 0.94) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.summit-map .leaflet-control-attribution {
+  background: hsl(var(--background) / 0.82) !important;
+  color: hsl(var(--muted-foreground)) !important;
+  font-size: 8px;
+}
+
+.summit-map-marker {
+  border: 0 !important;
+  background: transparent !important;
+}
+
+.summit-map-marker span {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border: 5px solid hsl(var(--background));
+  border-radius: 999px;
+  background: hsl(var(--primary));
+  box-shadow: var(--foundation-shadow-card);
+}

--- a/src/app/summit/london-map.tsx
+++ b/src/app/summit/london-map.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import type * as Leaflet from "leaflet";
+
+const MapContainer = dynamic(
+  () => import("react-leaflet").then((module) => module.MapContainer),
+  { ssr: false },
+);
+const Marker = dynamic(
+  () => import("react-leaflet").then((module) => module.Marker),
+  { ssr: false },
+);
+const TileLayer = dynamic(
+  () => import("react-leaflet").then((module) => module.TileLayer),
+  { ssr: false },
+);
+
+const centralLondon: [number, number] = [51.5074, -0.1278];
+
+function subscribeToTheme(onChange: () => void) {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributeFilter: ["class", "data-theme"],
+    attributes: true,
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeSnapshot() {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+export function LondonMap() {
+  const [leaflet, setLeaflet] = useState<typeof Leaflet | null>(null);
+  const effectiveTheme = useSyncExternalStore(
+    subscribeToTheme,
+    getThemeSnapshot,
+    () => "light",
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    import("leaflet").then((module) => {
+      if (active) setLeaflet(module.default);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const markerIcon = useMemo(
+    () =>
+      leaflet?.divIcon({
+        className: "summit-map-marker",
+        html: "<span aria-hidden=\"true\"></span>",
+        iconSize: [28, 28],
+        iconAnchor: [14, 14],
+      }),
+    [leaflet],
+  );
+
+  const tileUrl =
+    effectiveTheme === "dark"
+      ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+      : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+
+  return (
+    <figure className="overflow-hidden rounded-2xl border border-border bg-muted/30">
+      <div className="summit-map h-64 w-full bg-muted">
+        {leaflet && markerIcon ? (
+          <MapContainer
+            center={centralLondon}
+            zoom={11}
+            minZoom={9}
+            maxZoom={16}
+            scrollWheelZoom={false}
+            className="h-full w-full"
+          >
+            <TileLayer
+              key={tileUrl}
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+              url={tileUrl}
+            />
+            <Marker
+              position={centralLondon}
+              icon={markerIcon}
+              title="Central London"
+              keyboard={false}
+            />
+          </MapContainer>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-sm text-muted-foreground">Loading London map…</p>
+          </div>
+        )}
+      </div>
+      <figcaption className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
+        Central London · Exact venue to be confirmed
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/app/summit/page.tsx
+++ b/src/app/summit/page.tsx
@@ -1,0 +1,313 @@
+import type { Metadata } from "next";
+import {
+  Check,
+  Clock3,
+  Download,
+  MapPin,
+  Plus,
+  Sparkles,
+} from "lucide-react";
+
+import { RFDS } from "@/components/rfds";
+import {
+  faqItems,
+  participationPrinciples,
+  summitDays,
+  summitGoals,
+  workingGroups,
+  type AgendaItem,
+} from "./summit-data";
+import { SummitHero } from "./summit-hero";
+import styles from "./summit.module.css";
+
+export const metadata: Metadata = {
+  title: "React Foundation Summit 2026",
+  description:
+    "Participant guide for the first React Foundation Summit, taking place in London from 10–12 November 2026.",
+  openGraph: {
+    title: "React Foundation Summit 2026",
+    description: "Three days in London to align, collaborate, and shape what comes next for React.",
+    type: "website",
+  },
+};
+
+function SectionHeading({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="max-w-3xl">
+      <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+        {eyebrow}
+      </p>
+      <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-5xl">
+        {title}
+      </h2>
+      <p className="mt-5 text-base leading-7 text-muted-foreground sm:text-lg">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function Agenda({ items }: { items: readonly AgendaItem[] }) {
+  return (
+    <ol className="relative space-y-1">
+      <span
+        aria-hidden="true"
+        className={`${styles.agendaLine} absolute bottom-7 left-[0.7rem] top-7 w-px`}
+      />
+      {items.map((item) => (
+        <li key={`${item.time}-${item.title}`} className="relative grid gap-3 py-4 pl-10 sm:grid-cols-[8rem_1fr] sm:gap-6">
+          <span className="absolute left-1.5 top-6 h-3 w-3 rounded-full border-2 border-primary bg-card shadow-[0_0_12px_hsl(var(--primary)/0.65)]" />
+          <p className="font-mono text-xs font-medium uppercase tracking-wider text-primary">
+            {item.time}
+          </p>
+          <div>
+            <h4 className="font-semibold text-foreground">{item.title}</h4>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export default function SummitPage() {
+  return (
+    <main className={`${styles.microsite} min-h-screen overflow-hidden bg-background text-foreground`}>
+      <SummitHero />
+
+      <section id="why" className="scroll-mt-36 py-24 sm:py-32">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
+          <RFDS.ScrollReveal animation="fade-up">
+            <SectionHeading
+              eyebrow="Why we’re gathering"
+              title="A Foundation becomes real when its people meet."
+              description="Since its inception, the React Foundation has worked entirely at a distance. This summit is our first chance to share a room, build the connective tissue between groups, and decide how we move forward together."
+            />
+          </RFDS.ScrollReveal>
+
+          <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {summitGoals.map((goal, index) => {
+              const Icon = goal.icon;
+              return (
+                <RFDS.ScrollReveal key={goal.title} animation="fade-up" delay={index * 90}>
+                  <RFDS.SemanticCard variant="outlined" hover className="group h-full overflow-hidden p-6">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-primary/20 bg-primary/10 text-primary shadow-[0_0_24px_hsl(var(--primary)/0.08)] transition-transform group-hover:-translate-y-1">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </div>
+                    <p className="mt-7 font-mono text-xs text-muted-foreground">0{index + 1}</p>
+                    <h3 className="mt-2 text-lg font-semibold text-foreground">{goal.title}</h3>
+                    <p className="mt-3 text-sm leading-6 text-muted-foreground">{goal.description}</p>
+                  </RFDS.SemanticCard>
+                </RFDS.ScrollReveal>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section id="programme" className="scroll-mt-36 border-y border-border/60 bg-muted/35 py-24 sm:py-32">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
+          <RFDS.ScrollReveal animation="fade-up">
+            <SectionHeading
+              eyebrow="Three-day programme"
+              title="One summit. Three distinct modes."
+              description="We start by creating shared context, move into working sessions, and close with the Foundation’s first in-person board meeting. Session times are proposed and will be finalized with the venue."
+            />
+          </RFDS.ScrollReveal>
+
+          <div className="mt-14 space-y-6">
+            {summitDays.map((summitDay, index) => (
+              <RFDS.ScrollReveal key={summitDay.day} animation="fade-up" delay={index * 80}>
+                <RFDS.SemanticCard variant="outlined" className="overflow-hidden">
+                  <div className="grid lg:grid-cols-[20rem_1fr]">
+                    <div className="relative overflow-hidden border-b border-border bg-card p-7 lg:border-b-0 lg:border-r lg:p-9">
+                      <div aria-hidden="true" className="absolute -right-14 -top-14 h-44 w-44 rounded-full bg-primary/10 blur-3xl" />
+                      <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">{summitDay.day}</p>
+                      <p className={`${styles.dateNumber} mt-7 text-6xl font-semibold tracking-[-0.06em]`}>{10 + index}</p>
+                      <p className="mt-1 text-sm font-medium text-muted-foreground">{summitDay.date}</p>
+                      <h3 className="mt-8 text-2xl font-semibold text-foreground">{summitDay.label}</h3>
+                      <p className="mt-3 text-sm leading-6 text-muted-foreground">{summitDay.focus}</p>
+                      <RFDS.SemanticBadge variant={index === 2 ? "outline" : "default"} className="mt-6">
+                        {summitDay.audience}
+                      </RFDS.SemanticBadge>
+                    </div>
+                    <div className="bg-card p-7 lg:p-9">
+                      <Agenda items={summitDay.agenda} />
+                    </div>
+                  </div>
+                </RFDS.SemanticCard>
+              </RFDS.ScrollReveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="workshops" className="scroll-mt-36 py-24 sm:py-32">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
+          <div className="grid gap-16 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+            <RFDS.ScrollReveal animation="slide-right">
+              <SectionHeading
+                eyebrow="Wednesday workshops"
+                title="The room is the working surface."
+                description="Day 2 belongs to the working groups. Use it for the discussions and collaboration that are hardest to do across time zones and video calls."
+              />
+              <RFDS.SemanticAlert variant="default" title="Designed around overlaps" className="mt-8 border-primary/20 bg-primary/5">
+                Some members contribute to multiple groups. The detailed schedule will account for known conflicts, and groups can combine or split sessions around shared topics.
+              </RFDS.SemanticAlert>
+            </RFDS.ScrollReveal>
+
+            <RFDS.ScrollReveal animation="slide-left" delay={100}>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {workingGroups.map((group) => (
+                  <RFDS.SemanticCard key={group.name} variant="outlined" hover className="group flex items-start gap-4 p-5">
+                    <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-primary shadow-[0_0_14px_hsl(var(--primary)/0.7)]" />
+                    <div>
+                      <h3 className="font-semibold text-foreground group-hover:text-primary">{group.name}</h3>
+                      <p className="mt-1 text-xs leading-5 text-muted-foreground">{group.family}</p>
+                    </div>
+                  </RFDS.SemanticCard>
+                ))}
+              </div>
+            </RFDS.ScrollReveal>
+          </div>
+
+          <div className="mt-20 grid gap-px overflow-hidden rounded-3xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
+            {participationPrinciples.map((principle) => {
+              const Icon = principle.icon;
+              return (
+                <div key={principle.title} className="bg-card p-7">
+                  <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h3 className="mt-5 font-semibold text-foreground">{principle.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">{principle.text}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section id="plan" className="scroll-mt-36 border-y border-border/60 bg-muted/35 py-24 sm:py-32">
+        <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
+          <RFDS.ScrollReveal animation="fade-up">
+            <SectionHeading
+              eyebrow="Plan your summit"
+              title="What participants need to know now."
+              description="London and the dates are set. Venue, travel, accommodation, and catering details are still being coordinated and will be published here as they are confirmed."
+            />
+          </RFDS.ScrollReveal>
+
+          <div className="mt-14 grid gap-5 lg:grid-cols-3">
+            <RFDS.SemanticCard variant="outlined" className="p-7 lg:col-span-2">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <MapPin className="h-6 w-6" aria-hidden="true" />
+                </div>
+                <RFDS.SemanticBadge variant="warning">Venue to be confirmed</RFDS.SemanticBadge>
+              </div>
+              <h3 className="mt-7 text-2xl font-semibold text-foreground">London, United Kingdom</h3>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                London offers direct international connections and a strong local React community. The final venue is being coordinated; capacity, accessibility, and workshop space are part of that decision.
+              </p>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">International hub</span>
+                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">GMT in November</span>
+                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">Cool, wet weather likely</span>
+              </div>
+            </RFDS.SemanticCard>
+
+            <RFDS.SemanticCard variant="outlined" className="p-7">
+              <Clock3 className="h-6 w-6 text-primary" aria-hidden="true" />
+              <h3 className="mt-6 text-xl font-semibold text-foreground">Before you book</h3>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                Hold 10–12 November in your calendar. Wait for the logistics update before booking non-refundable travel or accommodation.
+              </p>
+              <RFDS.ButtonLink href="/summit-2026.ics" variant="secondary" size="sm" className="mt-6" download>
+                <Download className="h-4 w-4" aria-hidden="true" /> Add dates
+              </RFDS.ButtonLink>
+            </RFDS.SemanticCard>
+          </div>
+
+          <RFDS.SemanticCard variant="glass" className="mt-5 p-7 sm:p-9">
+            <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr]">
+              <div>
+                <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">Participant checklist</p>
+                <h3 className="mt-3 text-2xl font-semibold text-foreground">Come ready to contribute.</h3>
+              </div>
+              <ul className="grid gap-4 sm:grid-cols-2">
+                {[
+                  "Hold all three dates; confirm whether Day 3 applies to you",
+                  "Coordinate your working group’s Tuesday update",
+                  "Prioritize decisions and hands-on work for Wednesday",
+                  "Flag cross-group scheduling conflicts early",
+                  "Share accessibility and dietary needs when requested",
+                  "Check this page before making travel arrangements",
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-3 text-sm leading-6 text-muted-foreground">
+                    <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-success/10 text-success">
+                      <Check className="h-3 w-3" aria-hidden="true" />
+                    </span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </RFDS.SemanticCard>
+        </div>
+      </section>
+
+      <section id="faq" className="scroll-mt-36 py-24 sm:py-32">
+        <div className="mx-auto grid max-w-7xl gap-14 px-6 sm:px-8 lg:grid-cols-[0.75fr_1.25fr] lg:px-12">
+          <div className="lg:sticky lg:top-40 lg:self-start">
+            <RFDS.ScrollReveal animation="fade-up">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10 text-primary shadow-[0_0_30px_hsl(var(--primary)/0.12)]">
+                <Sparkles className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <SectionHeading
+                eyebrow="Participant FAQ"
+                title="The details, in one place."
+                description="This is the source of truth for summit participants. Confirmed information is stated plainly; open logistics are marked as such."
+              />
+              <p className="mt-6 text-xs text-muted-foreground">Last updated 22 July 2026 · Author: Nicola Corti</p>
+            </RFDS.ScrollReveal>
+          </div>
+
+          <div className="divide-y divide-border border-y border-border">
+            {faqItems.map((item) => (
+              <details key={item.question} className={`${styles.faq} group`}>
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-6 py-6 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring">
+                  <h3 className="font-semibold text-foreground sm:text-lg">{item.question}</h3>
+                  <span className={`${styles.faqIcon} flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground transition-transform duration-300`}>
+                    <Plus className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </summary>
+                <p className="max-w-3xl pb-7 pr-12 text-sm leading-7 text-muted-foreground sm:text-base">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden border-t border-border/60 py-24">
+        <div aria-hidden="true" className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-success/10" />
+        <RFDS.ScrollReveal animation="scale" className="mx-auto max-w-4xl px-6 text-center sm:px-8">
+          <RFDS.SemanticBadge variant="outline" className="border-primary/30 bg-background/50">10–12 November · London</RFDS.SemanticBadge>
+          <h2 className="mt-7 text-4xl font-semibold tracking-tight text-foreground sm:text-6xl">Let’s shape what comes next.</h2>
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
+            Bring your context, your hardest questions, and the work that deserves to happen together.
+          </p>
+          <RFDS.ButtonLink href="#programme" size="lg" className="mt-9">Review the programme</RFDS.ButtonLink>
+        </RFDS.ScrollReveal>
+      </section>
+
+      <RFDS.Footer />
+    </main>
+  );
+}

--- a/src/app/summit/page.tsx
+++ b/src/app/summit/page.tsx
@@ -29,19 +29,14 @@ export const metadata: Metadata = {
 };
 
 function SectionHeading({
-  eyebrow,
   title,
   description,
 }: {
-  eyebrow: string;
   title: string;
   description: string;
 }) {
   return (
     <div className="max-w-3xl">
-      <p className="mb-4 font-mono text-xs font-semibold uppercase tracking-[0.24em] text-primary">
-        {eyebrow}
-      </p>
       <h2 className="text-3xl font-semibold tracking-tight text-foreground sm:text-5xl">
         {title}
       </h2>
@@ -61,7 +56,6 @@ export default function SummitPage() {
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
-              eyebrow="Why we’re gathering"
               title="A Foundation becomes real when its people meet."
               description="This is our first chance to meet in person, connect across groups, and decide what comes next."
             />
@@ -91,7 +85,6 @@ export default function SummitPage() {
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
-              eyebrow="Programme at a glance"
               title="Programme"
               description="Travel days bookend three days together in London: one plenary day followed by two days dedicated to working groups."
             />
@@ -132,7 +125,6 @@ export default function SummitPage() {
           <div className="grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-start lg:gap-20">
             <RFDS.ScrollReveal animation="slide-right">
               <SectionHeading
-                eyebrow="Joining the summit"
                 title="An invite-only working summit."
                 description="Attendance is invite only for members of the React Foundation working groups."
               />
@@ -143,10 +135,7 @@ export default function SummitPage() {
 
             <RFDS.ScrollReveal animation="slide-left" delay={100}>
               <RFDS.SemanticCard variant="outlined" className="p-7 sm:p-9">
-                <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">
-                  Self-nominations
-                </p>
-                <h3 className="mt-4 text-2xl font-semibold text-foreground">
+                <h3 className="text-2xl font-semibold text-foreground">
                   Interested in taking part?
                 </h3>
                 <p className="mt-4 text-base leading-7 text-muted-foreground">
@@ -171,7 +160,6 @@ export default function SummitPage() {
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
-              eyebrow="Plan your summit"
               title="Logistics"
               description="London and the dates are set. Venue, travel, accommodation, and catering details are still being coordinated and will be published here as they are confirmed."
             />
@@ -214,7 +202,6 @@ export default function SummitPage() {
           <div className="lg:sticky lg:top-40 lg:self-start">
             <RFDS.ScrollReveal animation="fade-up">
               <SectionHeading
-                eyebrow="Participant FAQ"
                 title="The details, in one place."
                 description="This is the source of truth for summit participants. Confirmed information is stated plainly; open logistics are marked as such."
               />
@@ -228,8 +215,7 @@ export default function SummitPage() {
 
       <section className="border-t border-border/60 bg-muted/35 py-24">
         <RFDS.ScrollReveal animation="scale" className="mx-auto max-w-4xl px-6 text-center sm:px-8">
-          <RFDS.SemanticBadge variant="outline" className="border-primary/30 bg-background/50">10–12 November · London</RFDS.SemanticBadge>
-          <h2 className="mt-7 text-4xl font-semibold tracking-tight text-foreground sm:text-6xl">Let’s shape what comes next.</h2>
+          <h2 className="text-4xl font-semibold tracking-tight text-foreground sm:text-6xl">Let’s shape what comes next.</h2>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
             Bring your context and expertise to help build the future of React.
           </p>

--- a/src/app/summit/page.tsx
+++ b/src/app/summit/page.tsx
@@ -1,31 +1,28 @@
 import type { Metadata } from "next";
 import {
-  Check,
   Clock3,
-  Download,
   MapPin,
-  Plus,
-  Sparkles,
 } from "lucide-react";
 
 import { RFDS } from "@/components/rfds";
 import {
   faqItems,
-  participationPrinciples,
   summitDays,
   summitGoals,
-  workingGroups,
-  type AgendaItem,
 } from "./summit-data";
+import { LondonMap } from "./london-map";
+import { SummitCalendarMenu } from "./summit-calendar-menu";
+import { SummitFaq } from "./summit-faq";
 import { SummitHero } from "./summit-hero";
 import styles from "./summit.module.css";
+import "./leaflet.css";
 
 export const metadata: Metadata = {
-  title: "React Foundation Summit 2026",
+  title: "React Foundation Contributors Summit 2026",
   description:
-    "Participant guide for the first React Foundation Summit, taking place in London from 10–12 November 2026.",
+    "Participant guide for the first React Foundation Contributors Summit, taking place in London from 10–12 November 2026.",
   openGraph: {
-    title: "React Foundation Summit 2026",
+    title: "React Foundation Contributors Summit 2026",
     description: "Three days in London to align, collaborate, and shape what comes next for React.",
     type: "website",
   },
@@ -55,29 +52,6 @@ function SectionHeading({
   );
 }
 
-function Agenda({ items }: { items: readonly AgendaItem[] }) {
-  return (
-    <ol className="relative space-y-1">
-      <span
-        aria-hidden="true"
-        className={`${styles.agendaLine} absolute bottom-7 left-[0.7rem] top-7 w-px`}
-      />
-      {items.map((item) => (
-        <li key={`${item.time}-${item.title}`} className="relative grid gap-3 py-4 pl-10 sm:grid-cols-[8rem_1fr] sm:gap-6">
-          <span className="absolute left-1.5 top-6 h-3 w-3 rounded-full border-2 border-primary bg-card shadow-[0_0_12px_hsl(var(--primary)/0.65)]" />
-          <p className="font-mono text-xs font-medium uppercase tracking-wider text-primary">
-            {item.time}
-          </p>
-          <div>
-            <h4 className="font-semibold text-foreground">{item.title}</h4>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
-          </div>
-        </li>
-      ))}
-    </ol>
-  );
-}
-
 export default function SummitPage() {
   return (
     <main className={`${styles.microsite} min-h-screen overflow-hidden bg-background text-foreground`}>
@@ -89,7 +63,7 @@ export default function SummitPage() {
             <SectionHeading
               eyebrow="Why we’re gathering"
               title="A Foundation becomes real when its people meet."
-              description="Since its inception, the React Foundation has worked entirely at a distance. This summit is our first chance to share a room, build the connective tissue between groups, and decide how we move forward together."
+              description="This is our first chance to meet in person, connect across groups, and decide what comes next."
             />
           </RFDS.ScrollReveal>
 
@@ -99,7 +73,7 @@ export default function SummitPage() {
               return (
                 <RFDS.ScrollReveal key={goal.title} animation="fade-up" delay={index * 90}>
                   <RFDS.SemanticCard variant="outlined" hover className="group h-full overflow-hidden p-6">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-primary/20 bg-primary/10 text-primary shadow-[0_0_24px_hsl(var(--primary)/0.08)] transition-transform group-hover:-translate-y-1">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-primary/20 bg-primary/10 text-primary transition-transform group-hover:-translate-y-1">
                       <Icon className="h-5 w-5" aria-hidden="true" />
                     </div>
                     <p className="mt-7 font-mono text-xs text-muted-foreground">0{index + 1}</p>
@@ -117,32 +91,35 @@ export default function SummitPage() {
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
-              eyebrow="Three-day programme"
-              title="One summit. Three distinct modes."
-              description="We start by creating shared context, move into working sessions, and close with the Foundation’s first in-person board meeting. Session times are proposed and will be finalized with the venue."
+              eyebrow="Programme at a glance"
+              title="Programme"
+              description="Travel days bookend three days together in London: one plenary day followed by two days dedicated to working groups."
             />
           </RFDS.ScrollReveal>
 
-          <div className="mt-14 space-y-6">
+          <div className="mt-14 grid gap-4 md:grid-cols-2 lg:grid-cols-5">
             {summitDays.map((summitDay, index) => (
               <RFDS.ScrollReveal key={summitDay.day} animation="fade-up" delay={index * 80}>
-                <RFDS.SemanticCard variant="outlined" className="overflow-hidden">
-                  <div className="grid lg:grid-cols-[20rem_1fr]">
-                    <div className="relative overflow-hidden border-b border-border bg-card p-7 lg:border-b-0 lg:border-r lg:p-9">
-                      <div aria-hidden="true" className="absolute -right-14 -top-14 h-44 w-44 rounded-full bg-primary/10 blur-3xl" />
-                      <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">{summitDay.day}</p>
-                      <p className={`${styles.dateNumber} mt-7 text-6xl font-semibold tracking-[-0.06em]`}>{10 + index}</p>
-                      <p className="mt-1 text-sm font-medium text-muted-foreground">{summitDay.date}</p>
-                      <h3 className="mt-8 text-2xl font-semibold text-foreground">{summitDay.label}</h3>
-                      <p className="mt-3 text-sm leading-6 text-muted-foreground">{summitDay.focus}</p>
-                      <RFDS.SemanticBadge variant={index === 2 ? "outline" : "default"} className="mt-6">
-                        {summitDay.audience}
-                      </RFDS.SemanticBadge>
-                    </div>
-                    <div className="bg-card p-7 lg:p-9">
-                      <Agenda items={summitDay.agenda} />
-                    </div>
-                  </div>
+                <RFDS.SemanticCard
+                  variant="outlined"
+                  className={`h-full p-6 ${summitDay.isTravel ? "border-dashed border-border/70 bg-transparent" : "bg-card"}`}
+                >
+                  <p className={`font-mono text-xs font-semibold uppercase tracking-[0.18em] ${summitDay.isTravel ? "text-muted-foreground" : "text-primary"}`}>
+                    {summitDay.day}
+                  </p>
+                  <p className={`mt-7 font-semibold tracking-[-0.06em] ${summitDay.isTravel ? "text-3xl text-muted-foreground" : "text-5xl text-foreground"}`}>
+                    {summitDay.dateNumber}
+                  </p>
+                  <p className="mt-1 text-sm font-medium text-muted-foreground">{summitDay.date}</p>
+                  <h3 className={`mt-8 font-semibold ${summitDay.isTravel ? "text-base text-muted-foreground" : "text-xl text-foreground"}`}>
+                    {summitDay.label}
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-muted-foreground">{summitDay.focus}</p>
+                  {summitDay.audience ? (
+                    <p className="mt-6 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      {summitDay.audience}
+                    </p>
+                  ) : null}
                 </RFDS.SemanticCard>
               </RFDS.ScrollReveal>
             ))}
@@ -150,46 +127,42 @@ export default function SummitPage() {
         </div>
       </section>
 
-      <section id="workshops" className="scroll-mt-36 py-24 sm:py-32">
+      <section id="joining" className="scroll-mt-36 py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
-          <div className="grid gap-16 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div className="grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-start lg:gap-20">
             <RFDS.ScrollReveal animation="slide-right">
               <SectionHeading
-                eyebrow="Wednesday workshops"
-                title="The room is the working surface."
-                description="Day 2 belongs to the working groups. Use it for the discussions and collaboration that are hardest to do across time zones and video calls."
+                eyebrow="Joining the summit"
+                title="An invite-only working summit."
+                description="Attendance is invite only for members of the React Foundation working groups."
               />
-              <RFDS.SemanticAlert variant="default" title="Designed around overlaps" className="mt-8 border-primary/20 bg-primary/5">
-                Some members contribute to multiple groups. The detailed schedule will account for known conflicts, and groups can combine or split sessions around shared topics.
-              </RFDS.SemanticAlert>
+              <RFDS.SemanticBadge variant="outline" className="mt-7 border-primary/30">
+                Invite only
+              </RFDS.SemanticBadge>
             </RFDS.ScrollReveal>
 
             <RFDS.ScrollReveal animation="slide-left" delay={100}>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {workingGroups.map((group) => (
-                  <RFDS.SemanticCard key={group.name} variant="outlined" hover className="group flex items-start gap-4 p-5">
-                    <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-primary shadow-[0_0_14px_hsl(var(--primary)/0.7)]" />
-                    <div>
-                      <h3 className="font-semibold text-foreground group-hover:text-primary">{group.name}</h3>
-                      <p className="mt-1 text-xs leading-5 text-muted-foreground">{group.family}</p>
-                    </div>
-                  </RFDS.SemanticCard>
-                ))}
-              </div>
+              <RFDS.SemanticCard variant="outlined" className="p-7 sm:p-9">
+                <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+                  Self-nominations
+                </p>
+                <h3 className="mt-4 text-2xl font-semibold text-foreground">
+                  Interested in taking part?
+                </h3>
+                <p className="mt-4 text-base leading-7 text-muted-foreground">
+                  Folks can self-nominate using the form below.
+                </p>
+                <RFDS.ButtonLink
+                  href="https://example.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  variant="tertiary"
+                  className="mt-7 border-primary/30 bg-primary/5 hover:bg-primary/10"
+                >
+                  Self-nomination form
+                </RFDS.ButtonLink>
+              </RFDS.SemanticCard>
             </RFDS.ScrollReveal>
-          </div>
-
-          <div className="mt-20 grid gap-px overflow-hidden rounded-3xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
-            {participationPrinciples.map((principle) => {
-              const Icon = principle.icon;
-              return (
-                <div key={principle.title} className="bg-card p-7">
-                  <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
-                  <h3 className="mt-5 font-semibold text-foreground">{principle.title}</h3>
-                  <p className="mt-2 text-sm leading-6 text-muted-foreground">{principle.text}</p>
-                </div>
-              );
-            })}
           </div>
         </div>
       </section>
@@ -199,7 +172,7 @@ export default function SummitPage() {
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
               eyebrow="Plan your summit"
-              title="What participants need to know now."
+              title="Logistics"
               description="London and the dates are set. Venue, travel, accommodation, and catering details are still being coordinated and will be published here as they are confirmed."
             />
           </RFDS.ScrollReveal>
@@ -212,14 +185,14 @@ export default function SummitPage() {
                 </div>
                 <RFDS.SemanticBadge variant="warning">Venue to be confirmed</RFDS.SemanticBadge>
               </div>
-              <h3 className="mt-7 text-2xl font-semibold text-foreground">London, United Kingdom</h3>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-                London offers direct international connections and a strong local React community. The final venue is being coordinated; capacity, accessibility, and workshop space are part of that decision.
-              </p>
-              <div className="mt-7 flex flex-wrap gap-3">
-                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">International hub</span>
-                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">GMT in November</span>
-                <span className="rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground">Cool, wet weather likely</span>
+              <div className="mt-7 grid gap-8 md:grid-cols-[minmax(0,1fr)_18rem] md:items-start">
+                <div>
+                  <h3 className="text-2xl font-semibold text-foreground">London, United Kingdom</h3>
+                  <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                    London offers direct international connections and a strong local React community. The final venue is being coordinated; capacity, accessibility, and breakout space are part of that decision.
+                  </p>
+                </div>
+                <LondonMap />
               </div>
             </RFDS.SemanticCard>
 
@@ -227,39 +200,12 @@ export default function SummitPage() {
               <Clock3 className="h-6 w-6 text-primary" aria-hidden="true" />
               <h3 className="mt-6 text-xl font-semibold text-foreground">Before you book</h3>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                Hold 10–12 November in your calendar. Wait for the logistics update before booking non-refundable travel or accommodation.
+                Plan to arrive on Monday 9 November and depart on Friday 13 November. Wait for the logistics update before booking non-refundable travel or accommodation.
               </p>
-              <RFDS.ButtonLink href="/summit-2026.ics" variant="secondary" size="sm" className="mt-6" download>
-                <Download className="h-4 w-4" aria-hidden="true" /> Add dates
-              </RFDS.ButtonLink>
+              <SummitCalendarMenu variant="secondary" size="sm" className="mt-6" />
             </RFDS.SemanticCard>
           </div>
 
-          <RFDS.SemanticCard variant="glass" className="mt-5 p-7 sm:p-9">
-            <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr]">
-              <div>
-                <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-primary">Participant checklist</p>
-                <h3 className="mt-3 text-2xl font-semibold text-foreground">Come ready to contribute.</h3>
-              </div>
-              <ul className="grid gap-4 sm:grid-cols-2">
-                {[
-                  "Hold all three dates; confirm whether Day 3 applies to you",
-                  "Coordinate your working group’s Tuesday update",
-                  "Prioritize decisions and hands-on work for Wednesday",
-                  "Flag cross-group scheduling conflicts early",
-                  "Share accessibility and dietary needs when requested",
-                  "Check this page before making travel arrangements",
-                ].map((item) => (
-                  <li key={item} className="flex items-start gap-3 text-sm leading-6 text-muted-foreground">
-                    <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-success/10 text-success">
-                      <Check className="h-3 w-3" aria-hidden="true" />
-                    </span>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </RFDS.SemanticCard>
         </div>
       </section>
 
@@ -267,41 +213,25 @@ export default function SummitPage() {
         <div className="mx-auto grid max-w-7xl gap-14 px-6 sm:px-8 lg:grid-cols-[0.75fr_1.25fr] lg:px-12">
           <div className="lg:sticky lg:top-40 lg:self-start">
             <RFDS.ScrollReveal animation="fade-up">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10 text-primary shadow-[0_0_30px_hsl(var(--primary)/0.12)]">
-                <Sparkles className="h-5 w-5" aria-hidden="true" />
-              </div>
               <SectionHeading
                 eyebrow="Participant FAQ"
                 title="The details, in one place."
                 description="This is the source of truth for summit participants. Confirmed information is stated plainly; open logistics are marked as such."
               />
-              <p className="mt-6 text-xs text-muted-foreground">Last updated 22 July 2026 · Author: Nicola Corti</p>
+              <p className="mt-6 text-xs text-muted-foreground">Last updated 22 July 2026</p>
             </RFDS.ScrollReveal>
           </div>
 
-          <div className="divide-y divide-border border-y border-border">
-            {faqItems.map((item) => (
-              <details key={item.question} className={`${styles.faq} group`}>
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-6 py-6 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring">
-                  <h3 className="font-semibold text-foreground sm:text-lg">{item.question}</h3>
-                  <span className={`${styles.faqIcon} flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground transition-transform duration-300`}>
-                    <Plus className="h-4 w-4" aria-hidden="true" />
-                  </span>
-                </summary>
-                <p className="max-w-3xl pb-7 pr-12 text-sm leading-7 text-muted-foreground sm:text-base">{item.answer}</p>
-              </details>
-            ))}
-          </div>
+          <SummitFaq items={faqItems} />
         </div>
       </section>
 
-      <section className="relative overflow-hidden border-t border-border/60 py-24">
-        <div aria-hidden="true" className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-success/10" />
+      <section className="border-t border-border/60 bg-muted/35 py-24">
         <RFDS.ScrollReveal animation="scale" className="mx-auto max-w-4xl px-6 text-center sm:px-8">
           <RFDS.SemanticBadge variant="outline" className="border-primary/30 bg-background/50">10–12 November · London</RFDS.SemanticBadge>
           <h2 className="mt-7 text-4xl font-semibold tracking-tight text-foreground sm:text-6xl">Let’s shape what comes next.</h2>
           <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
-            Bring your context, your hardest questions, and the work that deserves to happen together.
+            Bring your context and expertise to help build the future of React.
           </p>
           <RFDS.ButtonLink href="#programme" size="lg" className="mt-9">Review the programme</RFDS.ButtonLink>
         </RFDS.ScrollReveal>

--- a/src/app/summit/summit-calendar-menu.tsx
+++ b/src/app/summit/summit-calendar-menu.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { CalendarDays, ChevronDown, Download, ExternalLink } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { RFDS } from "@/components/rfds";
+import { cn } from "@/lib/cn";
+
+const eventName = "React Foundation Contributors Summit 2026";
+const eventLocation = "London, United Kingdom";
+const summitUrl = "https://react.foundation/summit";
+
+const googleCalendarUrl = `https://calendar.google.com/calendar/render?${new URLSearchParams({
+  action: "TEMPLATE",
+  text: eventName,
+  dates: "20261110/20261113",
+  details: summitUrl,
+  location: eventLocation,
+}).toString()}`;
+
+const outlookCalendarUrl = `https://outlook.live.com/calendar/0/deeplink/compose?${new URLSearchParams({
+  path: "/calendar/action/compose",
+  rru: "addevent",
+  subject: eventName,
+  startdt: "2026-11-10",
+  enddt: "2026-11-13",
+  allday: "true",
+  body: summitUrl,
+  location: eventLocation,
+}).toString()}`;
+
+interface SummitCalendarMenuProps {
+  className?: string;
+  size?: "sm" | "lg";
+  variant?: "primary" | "secondary" | "tertiary";
+}
+
+export function SummitCalendarMenu({
+  className,
+  size = "lg",
+  variant = "primary",
+}: SummitCalendarMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !containerRef.current?.contains(event.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <RFDS.Button
+        ref={buttonRef}
+        type="button"
+        variant={variant}
+        size={size}
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        aria-haspopup="true"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <CalendarDays className="h-4 w-4" aria-hidden="true" />
+        Add to your calendar
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 transition-transform motion-reduce:transition-none",
+            isOpen && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+      </RFDS.Button>
+
+      {isOpen ? (
+        <div
+          id={menuId}
+          aria-label="Calendar options"
+          className="absolute left-0 top-[calc(100%+0.5rem)] z-50 w-72 overflow-hidden rounded-2xl border border-border bg-background p-2 shadow-soft"
+        >
+          <a
+            href={googleCalendarUrl}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            Google Calendar
+            <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </a>
+          <a
+            href={outlookCalendarUrl}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            Outlook
+            <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </a>
+          <a
+            href="/summit-2026.ics"
+            download
+            onClick={() => setIsOpen(false)}
+            className="flex items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            Apple or other calendar
+            <Download className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/summit/summit-data.ts
+++ b/src/app/summit/summit-data.ts
@@ -1,12 +1,8 @@
 import type { LucideIcon } from "lucide-react";
 import {
-  Blocks,
   Compass,
   Handshake,
   Landmark,
-  MessagesSquare,
-  Network,
-  Route,
   UsersRound,
 } from "lucide-react";
 
@@ -16,24 +12,24 @@ export interface SummitGoal {
   title: string;
 }
 
-export interface AgendaItem {
-  description: string;
-  time: string;
-  title: string;
-}
-
 export interface SummitDay {
-  agenda: readonly AgendaItem[];
-  audience: string;
+  audience?: string;
   date: string;
+  dateNumber: string;
   day: string;
   focus: string;
+  isTravel: boolean;
   label: string;
 }
 
 export interface FaqItem {
   answer: string;
+  link?: {
+    href: string;
+    label: string;
+  };
   question: string;
+  updatedAt?: string;
 }
 
 export const summitGoals: readonly SummitGoal[] = [
@@ -43,7 +39,7 @@ export const summitGoals: readonly SummitGoal[] = [
     icon: UsersRound,
   },
   {
-    title: "Set direction",
+    title: "Shape the roadmap",
     description: "Align working groups and subteams on priorities, active projects, and roadmaps.",
     icon: Compass,
   },
@@ -60,154 +56,93 @@ export const summitGoals: readonly SummitGoal[] = [
 ];
 export const summitDays: readonly SummitDay[] = [
   {
-    day: "Day 01",
-    date: "Tuesday, 10 November",
+    day: "Monday",
+    dateNumber: "09",
+    date: "November",
+    label: "Travel day",
+    audience: "Arrivals",
+    focus: "Travel to London and settle in ahead of the summit.",
+    isTravel: true,
+  },
+  {
+    day: "Tuesday",
+    dateNumber: "10",
+    date: "November",
     label: "Plenary sessions",
-    audience: "All summit participants",
-    focus: "Foundation-wide context, strategy, and governance",
-    agenda: [
-      {
-        time: "Morning",
-        title: "Welcome & keynote",
-        description: "Foundation leadership opens with the vision, mission, and outcomes for our time together.",
-      },
-      {
-        time: "Morning",
-        title: "State of React",
-        description: "A shared view of React today, the ecosystem around it, and the industry challenges ahead.",
-      },
-      {
-        time: "Late morning",
-        title: "Working group updates",
-        description: "Brief updates from each group: achievements, current state, and open challenges.",
-      },
-      {
-        time: "Afternoon",
-        title: "Strategic direction",
-        description: "A facilitated discussion on next-year priorities and cross-cutting themes.",
-      },
-      {
-        time: "Afternoon",
-        title: "Governance & process",
-        description: "Leadership representation, the RCP process, membership policies, and coordination.",
-      },
-      {
-        time: "Late afternoon",
-        title: "Lightning talks & open floor",
-        description: "Short member-led talks, demos, proposals, and topics that deserve the room’s attention.",
-      },
-      {
-        time: "Evening",
-        title: "Social dinner",
-        description: "An informal evening for conversation, connection, and team building.",
-      },
-    ],
+    focus: "Shared Foundation context, group updates, roadmap alignment, and cross-group priorities.",
+    isTravel: false,
   },
   {
-    day: "Day 02",
-    date: "Wednesday, 11 November",
-    label: "Working group workshops",
-    audience: "All summit participants",
-    focus: "Deep dives, roadmap planning, and hands-on collaboration",
-    agenda: [
-      {
-        time: "All day",
-        title: "Parallel workshops",
-        description: "Groups set focused agendas around roadmap planning, backlog triage, architecture, and working sessions.",
-      },
-      {
-        time: "Throughout",
-        title: "Cross-group sessions",
-        description: "Groups can combine or split around shared topics; cross-cutting collaboration is encouraged.",
-      },
-      {
-        time: "Scheduling note",
-        title: "Multiple memberships",
-        description: "The agenda will account for people who contribute to more than one group, including DevX and React Native.",
-      },
-    ],
+    day: "Wednesday",
+    dateNumber: "11",
+    date: "November",
+    label: "Working group day",
+    focus: "Roadmap planning, deep dives, and hands-on collaboration within and across groups.",
+    isTravel: false,
   },
   {
-    day: "Day 03",
-    date: "Thursday, 12 November",
-    label: "Board meeting",
-    audience: "React Foundation Board only",
-    focus: "The Foundation’s first in-person board meeting",
-    agenda: [
-      {
-        time: "Board schedule",
-        title: "In-person board meeting",
-        description: "A dedicated day for React Foundation Board members. Days 1 and 2 conclude the general summit programme.",
-      },
-    ],
+    day: "Thursday",
+    dateNumber: "12",
+    date: "November",
+    label: "Working group day",
+    focus: "Continue working sessions, resolve dependencies, and agree on next steps.",
+    isTravel: false,
+  },
+  {
+    day: "Friday",
+    dateNumber: "13",
+    date: "November",
+    label: "Travel day",
+    audience: "Departures",
+    focus: "Depart London after three days of summit sessions.",
+    isTravel: true,
   },
 ];
-
-export const workingGroups = [
-  { name: "Core Runtime & Renderer", family: "React Native" },
-  { name: "Platform Expertise", family: "React Native · iOS, Android & out-of-tree" },
-  { name: "Stable API", family: "React Native" },
-  { name: "Distribution", family: "React Native" },
-  { name: "React Fiber", family: "Foundation working group" },
-  { name: "DevX / Developer Tools", family: "Foundation working group" },
-  { name: "Server", family: "Foundation working group" },
-  { name: "Compiler", family: "Foundation working group" },
-] as const;
-
-export const participationPrinciples = [
-  { icon: Route, title: "Plan for outcomes", text: "Arrive with the decisions, dependencies, and roadmap questions your group needs to move forward." },
-  { icon: MessagesSquare, title: "Share the context", text: "Use plenaries to make challenges legible across groups, not only within your immediate team." },
-  { icon: Network, title: "Cross the boundaries", text: "Seek out adjacent groups where APIs, tooling, platforms, or governance overlap." },
-  { icon: Blocks, title: "Make together", text: "Reserve workshop time for real collaboration: triage, design, writing, prototyping, and decisions." },
-] as const;
 
 export const faqItems: readonly FaqItem[] = [
   {
     question: "When and where is the summit?",
-    answer: "The summit takes place in London from Tuesday 10 to Thursday 12 November 2026. Days 1 and 2 are for all summit participants; Day 3 is reserved for the React Foundation Board. The exact London venue is still to be confirmed.",
+    answer: "The summit sessions take place in London from Tuesday 10 to Thursday 12 November 2026. Monday 9 and Friday 13 November are travel days. The exact London venue is still to be confirmed.",
   },
   {
     question: "Who is invited?",
-    answer: "The event is being planned for approximately 75–100 React Foundation members across the technical working groups. Attendance is based on the summit participant roster. The board meeting on Thursday is limited to React Foundation Board members.",
+    answer: "Attendance is invite only for members of the React Foundation working groups. Folks can also self-nominate using the form linked on this page.",
   },
   {
     question: "Is this a public conference?",
-    answer: "No. The current format is a working summit for Foundation members, not a public conference. Whether any session or related community event will be opened more broadly remains under consideration.",
+    answer: "No. The current format is a working summit, not a public conference. Non-members of the React Foundation can",
+    link: {
+      href: "#joining",
+      label: "self-nominate using the form.",
+    },
   },
   {
     question: "What is the format?",
-    answer: "Tuesday is a shared plenary day covering Foundation context, strategy, working group updates, and governance. Wednesday is a workshop day with parallel working group sessions. Thursday is the Foundation Board meeting.",
+    answer: "Tuesday is a shared plenary day covering Foundation context, working group updates, roadmap alignment, and cross-group priorities. Wednesday and Thursday are dedicated to working group sessions.",
   },
   {
     question: "What if I belong to more than one working group?",
-    answer: "You are not the only one. Overlapping memberships are a known scheduling constraint, especially across DevX and React Native. Working groups may combine or split sessions, and cross-cutting sessions are encouraged. The detailed workshop timetable will be coordinated around known overlaps.",
+    answer: "You are not the only one. Overlapping memberships are a known scheduling constraint, especially across DevX and React Native. Working groups may combine or split sessions, and cross-cutting sessions are encouraged. The detailed schedule will be coordinated around known overlaps.",
   },
   {
     question: "Which working groups will meet?",
     answer: "The current plan includes React Native subteams for Core Runtime & Renderer, Platform Expertise, Stable API, and Distribution, alongside React Fiber, DevX / Developer Tools, Server, and Compiler groups.",
   },
   {
-    question: "What should my working group prepare?",
-    answer: "Each group owns its workshop agenda. Useful preparation includes a short state-of-the-group update for Tuesday and a prioritized list of roadmap decisions, backlog items, architecture topics, and hands-on work for Wednesday.",
-  },
-  {
     question: "Are travel and accommodation arranged?",
-    answer: "Travel coordination, accommodation guidance, and the reimbursement process have not yet been finalized. Participants should wait for the logistics update before making non-refundable bookings.",
+    answer: "Travel coordination, accommodation guidance, and reimbursement details will be shared with participants. If you have special travel needs, please include them in the registration form sent to participants by email.",
   },
   {
     question: "Will meals be provided?",
-    answer: "A social dinner is planned for Tuesday evening. Catering and dietary-request details for the full event will be shared when the venue and logistics plan are confirmed.",
-  },
-  {
-    question: "Will there be a community meetup?",
-    answer: "A pre- or post-event activity, potentially connected with the London React community, is being considered but is not yet part of the confirmed programme.",
+    answer: "Catering and dietary-request details for the event will be shared when the venue and logistics plan are confirmed.",
   },
   {
     question: "When will the detailed agenda be available?",
-    answer: "The programme on this page is the proposed shape of the summit. Exact session times, rooms, facilitators, and workshop schedules will be added after the venue and working group agendas are confirmed.",
+    answer: "The final agenda will be published in due course.",
   },
   {
     question: "Where will updates be published?",
-    answer: "This page is the participant source of truth and will be updated as venue, logistics, travel, and detailed scheduling decisions are finalized. It was last updated on 22 July 2026.",
+    answer: "This page is the participant source of truth and will be updated as venue, logistics, travel, and detailed scheduling decisions are finalized.",
+    updatedAt: "22 July 2026",
   },
 ];

--- a/src/app/summit/summit-data.ts
+++ b/src/app/summit/summit-data.ts
@@ -1,0 +1,213 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Blocks,
+  Compass,
+  Handshake,
+  Landmark,
+  MessagesSquare,
+  Network,
+  Route,
+  UsersRound,
+} from "lucide-react";
+
+export interface SummitGoal {
+  description: string;
+  icon: LucideIcon;
+  title: string;
+}
+
+export interface AgendaItem {
+  description: string;
+  time: string;
+  title: string;
+}
+
+export interface SummitDay {
+  agenda: readonly AgendaItem[];
+  audience: string;
+  date: string;
+  day: string;
+  focus: string;
+  label: string;
+}
+
+export interface FaqItem {
+  answer: string;
+  question: string;
+}
+
+export const summitGoals: readonly SummitGoal[] = [
+  {
+    title: "Establish our identity",
+    description: "Bring every technical working group together in person for the first time.",
+    icon: UsersRound,
+  },
+  {
+    title: "Set direction",
+    description: "Align working groups and subteams on priorities, active projects, and roadmaps.",
+    icon: Compass,
+  },
+  {
+    title: "Build trust",
+    description: "Create the relationships that make thoughtful remote collaboration work.",
+    icon: Handshake,
+  },
+  {
+    title: "Formalize governance",
+    description: "Resolve leadership, membership, and cross-cutting coordination questions.",
+    icon: Landmark,
+  },
+];
+export const summitDays: readonly SummitDay[] = [
+  {
+    day: "Day 01",
+    date: "Tuesday, 10 November",
+    label: "Plenary sessions",
+    audience: "All summit participants",
+    focus: "Foundation-wide context, strategy, and governance",
+    agenda: [
+      {
+        time: "Morning",
+        title: "Welcome & keynote",
+        description: "Foundation leadership opens with the vision, mission, and outcomes for our time together.",
+      },
+      {
+        time: "Morning",
+        title: "State of React",
+        description: "A shared view of React today, the ecosystem around it, and the industry challenges ahead.",
+      },
+      {
+        time: "Late morning",
+        title: "Working group updates",
+        description: "Brief updates from each group: achievements, current state, and open challenges.",
+      },
+      {
+        time: "Afternoon",
+        title: "Strategic direction",
+        description: "A facilitated discussion on next-year priorities and cross-cutting themes.",
+      },
+      {
+        time: "Afternoon",
+        title: "Governance & process",
+        description: "Leadership representation, the RCP process, membership policies, and coordination.",
+      },
+      {
+        time: "Late afternoon",
+        title: "Lightning talks & open floor",
+        description: "Short member-led talks, demos, proposals, and topics that deserve the room’s attention.",
+      },
+      {
+        time: "Evening",
+        title: "Social dinner",
+        description: "An informal evening for conversation, connection, and team building.",
+      },
+    ],
+  },
+  {
+    day: "Day 02",
+    date: "Wednesday, 11 November",
+    label: "Working group workshops",
+    audience: "All summit participants",
+    focus: "Deep dives, roadmap planning, and hands-on collaboration",
+    agenda: [
+      {
+        time: "All day",
+        title: "Parallel workshops",
+        description: "Groups set focused agendas around roadmap planning, backlog triage, architecture, and working sessions.",
+      },
+      {
+        time: "Throughout",
+        title: "Cross-group sessions",
+        description: "Groups can combine or split around shared topics; cross-cutting collaboration is encouraged.",
+      },
+      {
+        time: "Scheduling note",
+        title: "Multiple memberships",
+        description: "The agenda will account for people who contribute to more than one group, including DevX and React Native.",
+      },
+    ],
+  },
+  {
+    day: "Day 03",
+    date: "Thursday, 12 November",
+    label: "Board meeting",
+    audience: "React Foundation Board only",
+    focus: "The Foundation’s first in-person board meeting",
+    agenda: [
+      {
+        time: "Board schedule",
+        title: "In-person board meeting",
+        description: "A dedicated day for React Foundation Board members. Days 1 and 2 conclude the general summit programme.",
+      },
+    ],
+  },
+];
+
+export const workingGroups = [
+  { name: "Core Runtime & Renderer", family: "React Native" },
+  { name: "Platform Expertise", family: "React Native · iOS, Android & out-of-tree" },
+  { name: "Stable API", family: "React Native" },
+  { name: "Distribution", family: "React Native" },
+  { name: "React Fiber", family: "Foundation working group" },
+  { name: "DevX / Developer Tools", family: "Foundation working group" },
+  { name: "Server", family: "Foundation working group" },
+  { name: "Compiler", family: "Foundation working group" },
+] as const;
+
+export const participationPrinciples = [
+  { icon: Route, title: "Plan for outcomes", text: "Arrive with the decisions, dependencies, and roadmap questions your group needs to move forward." },
+  { icon: MessagesSquare, title: "Share the context", text: "Use plenaries to make challenges legible across groups, not only within your immediate team." },
+  { icon: Network, title: "Cross the boundaries", text: "Seek out adjacent groups where APIs, tooling, platforms, or governance overlap." },
+  { icon: Blocks, title: "Make together", text: "Reserve workshop time for real collaboration: triage, design, writing, prototyping, and decisions." },
+] as const;
+
+export const faqItems: readonly FaqItem[] = [
+  {
+    question: "When and where is the summit?",
+    answer: "The summit takes place in London from Tuesday 10 to Thursday 12 November 2026. Days 1 and 2 are for all summit participants; Day 3 is reserved for the React Foundation Board. The exact London venue is still to be confirmed.",
+  },
+  {
+    question: "Who is invited?",
+    answer: "The event is being planned for approximately 75–100 React Foundation members across the technical working groups. Attendance is based on the summit participant roster. The board meeting on Thursday is limited to React Foundation Board members.",
+  },
+  {
+    question: "Is this a public conference?",
+    answer: "No. The current format is a working summit for Foundation members, not a public conference. Whether any session or related community event will be opened more broadly remains under consideration.",
+  },
+  {
+    question: "What is the format?",
+    answer: "Tuesday is a shared plenary day covering Foundation context, strategy, working group updates, and governance. Wednesday is a workshop day with parallel working group sessions. Thursday is the Foundation Board meeting.",
+  },
+  {
+    question: "What if I belong to more than one working group?",
+    answer: "You are not the only one. Overlapping memberships are a known scheduling constraint, especially across DevX and React Native. Working groups may combine or split sessions, and cross-cutting sessions are encouraged. The detailed workshop timetable will be coordinated around known overlaps.",
+  },
+  {
+    question: "Which working groups will meet?",
+    answer: "The current plan includes React Native subteams for Core Runtime & Renderer, Platform Expertise, Stable API, and Distribution, alongside React Fiber, DevX / Developer Tools, Server, and Compiler groups.",
+  },
+  {
+    question: "What should my working group prepare?",
+    answer: "Each group owns its workshop agenda. Useful preparation includes a short state-of-the-group update for Tuesday and a prioritized list of roadmap decisions, backlog items, architecture topics, and hands-on work for Wednesday.",
+  },
+  {
+    question: "Are travel and accommodation arranged?",
+    answer: "Travel coordination, accommodation guidance, and the reimbursement process have not yet been finalized. Participants should wait for the logistics update before making non-refundable bookings.",
+  },
+  {
+    question: "Will meals be provided?",
+    answer: "A social dinner is planned for Tuesday evening. Catering and dietary-request details for the full event will be shared when the venue and logistics plan are confirmed.",
+  },
+  {
+    question: "Will there be a community meetup?",
+    answer: "A pre- or post-event activity, potentially connected with the London React community, is being considered but is not yet part of the confirmed programme.",
+  },
+  {
+    question: "When will the detailed agenda be available?",
+    answer: "The programme on this page is the proposed shape of the summit. Exact session times, rooms, facilitators, and workshop schedules will be added after the venue and working group agendas are confirmed.",
+  },
+  {
+    question: "Where will updates be published?",
+    answer: "This page is the participant source of truth and will be updated as venue, logistics, travel, and detailed scheduling decisions are finalized. It was last updated on 22 July 2026.",
+  },
+];

--- a/src/app/summit/summit-faq.tsx
+++ b/src/app/summit/summit-faq.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useId, useState } from "react";
+
+import { RFDS } from "@/components/rfds";
+import type { FaqItem } from "./summit-data";
+
+function SummitFaqItem({ item }: { item: FaqItem }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={contentId}
+        onClick={() => setIsOpen((open) => !open)}
+        className="flex w-full items-center justify-between gap-6 py-6 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+      >
+        <span className="font-semibold text-foreground sm:text-lg">{item.question}</span>
+        <span
+          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground transition-transform duration-300 motion-reduce:transition-none ${isOpen ? "rotate-45" : ""}`}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </span>
+      </button>
+
+      <RFDS.AccordionContent isOpen={isOpen} duration={300}>
+        <div id={contentId}>
+          <p className="max-w-3xl pb-7 pr-12 text-sm leading-7 text-muted-foreground sm:text-base">
+            {item.answer}
+            {item.link ? (
+              <>
+                {" "}
+                <a
+                  href={item.link.href}
+                  className="font-medium text-primary underline decoration-primary/35 underline-offset-4 transition hover:decoration-primary"
+                >
+                  {item.link.label}
+                </a>
+              </>
+            ) : null}
+            {item.updatedAt ? (
+              <span className="mt-3 block">
+                It was last updated on{" "}
+                <strong className="font-semibold text-foreground">{item.updatedAt}</strong>.
+              </span>
+            ) : null}
+          </p>
+        </div>
+      </RFDS.AccordionContent>
+    </div>
+  );
+}
+
+export function SummitFaq({ items }: { items: readonly FaqItem[] }) {
+  return (
+    <div className="divide-y divide-border border-y border-border">
+      {items.map((item) => (
+        <SummitFaqItem key={item.question} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/summit/summit-hero.tsx
+++ b/src/app/summit/summit-hero.tsx
@@ -2,18 +2,18 @@ import Image from "next/image";
 import {
   ArrowDown,
   CalendarDays,
-  Download,
   MapPin,
   UsersRound,
 } from "lucide-react";
 
 import { RFDS } from "@/components/rfds";
+import { SummitCalendarMenu } from "./summit-calendar-menu";
 import styles from "./summit.module.css";
 
 const navigation = [
   { href: "#why", label: "Purpose" },
   { href: "#programme", label: "Programme" },
-  { href: "#workshops", label: "Workshops" },
+  { href: "#joining", label: "Joining" },
   { href: "#plan", label: "Plan" },
   { href: "#faq", label: "FAQ" },
 ] as const;
@@ -22,22 +22,19 @@ export function SummitHero() {
   return (
     <>
       <section className="relative flex min-h-[calc(100svh-5rem)] items-center pt-28">
-        <div aria-hidden="true" className={`${styles.gridBackdrop} absolute inset-0 -z-20`} />
-        <div aria-hidden="true" className={`${styles.heroGlow} absolute inset-[-20%] -z-10`} />
-
         <div className="mx-auto grid w-full max-w-7xl gap-14 px-6 py-16 sm:px-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:px-12 lg:py-24">
           <div>
             <RFDS.Pill tone="sky" className="border-primary/30 bg-primary/5 text-foreground">
-              The first gathering · London 2026
+              November 2026 · London
             </RFDS.Pill>
             <h1 className="mt-8 text-5xl font-semibold leading-[0.95] tracking-[-0.055em] text-foreground sm:text-7xl lg:text-[5.6rem]">
-              React Foundation
-              <span className="block bg-gradient-to-r from-primary via-primary to-success bg-clip-text text-transparent">
-                Summit
+              Contributors
+              <span className="block text-primary">
+                Summit 2026
               </span>
             </h1>
             <p className="mt-8 max-w-xl text-lg leading-8 text-muted-foreground sm:text-xl">
-              Three days in London to turn a distributed Foundation into a connected community—with shared direction, stronger relationships, and momentum for what comes next.
+              Three days in London to build the roadmap of what comes next for React.
             </p>
 
             <div className="mt-9 flex flex-wrap gap-3">
@@ -45,10 +42,7 @@ export function SummitHero() {
                 Explore the programme
                 <ArrowDown className="h-4 w-4" aria-hidden="true" />
               </RFDS.ButtonLink>
-              <RFDS.ButtonLink href="/summit-2026.ics" variant="tertiary" size="lg" download>
-                <Download className="h-4 w-4" aria-hidden="true" />
-                Add to calendar
-              </RFDS.ButtonLink>
+              <SummitCalendarMenu variant="tertiary" />
             </div>
 
             <dl className="mt-12 grid max-w-2xl gap-6 border-t border-border/70 pt-7 sm:grid-cols-3">
@@ -66,9 +60,9 @@ export function SummitHero() {
               </div>
               <div>
                 <dt className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
-                  <UsersRound className="h-4 w-4 text-primary" aria-hidden="true" /> Gathering
+                  <UsersRound className="h-4 w-4 text-primary" aria-hidden="true" /> Attendance
                 </dt>
-                <dd className="mt-2 font-semibold text-foreground">75–100 members</dd>
+                <dd className="mt-2 font-semibold text-foreground">Invite only</dd>
               </div>
             </dl>
           </div>
@@ -77,16 +71,16 @@ export function SummitHero() {
             <div className={styles.orbitOne} />
             <div className={styles.orbitTwo} />
             <div className={styles.orbitThree} />
-            <div className="absolute inset-1/2 flex h-36 w-36 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-primary/25 bg-card/75 shadow-[0_0_80px_hsl(var(--primary)/0.25)] backdrop-blur-xl">
+            <div className="absolute inset-1/2 flex h-36 w-36 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-primary/25 bg-card/75 backdrop-blur-xl">
               <Image
                 src="/react-logo.svg"
                 alt=""
                 width={96}
                 height={96}
-                className={styles.reactMark}
               />
             </div>
             <span className="absolute left-[10%] top-[22%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">align</span>
+            <span className="absolute right-[10%] top-[18%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">share</span>
             <span className="absolute bottom-[18%] right-[6%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">build</span>
             <span className="absolute bottom-[12%] left-[12%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">connect</span>
           </div>

--- a/src/app/summit/summit-hero.tsx
+++ b/src/app/summit/summit-hero.tsx
@@ -1,0 +1,107 @@
+import Image from "next/image";
+import {
+  ArrowDown,
+  CalendarDays,
+  Download,
+  MapPin,
+  UsersRound,
+} from "lucide-react";
+
+import { RFDS } from "@/components/rfds";
+import styles from "./summit.module.css";
+
+const navigation = [
+  { href: "#why", label: "Purpose" },
+  { href: "#programme", label: "Programme" },
+  { href: "#workshops", label: "Workshops" },
+  { href: "#plan", label: "Plan" },
+  { href: "#faq", label: "FAQ" },
+] as const;
+
+export function SummitHero() {
+  return (
+    <>
+      <section className="relative flex min-h-[calc(100svh-5rem)] items-center pt-28">
+        <div aria-hidden="true" className={`${styles.gridBackdrop} absolute inset-0 -z-20`} />
+        <div aria-hidden="true" className={`${styles.heroGlow} absolute inset-[-20%] -z-10`} />
+
+        <div className="mx-auto grid w-full max-w-7xl gap-14 px-6 py-16 sm:px-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:px-12 lg:py-24">
+          <div>
+            <RFDS.Pill tone="sky" className="border-primary/30 bg-primary/5 text-foreground">
+              The first gathering · London 2026
+            </RFDS.Pill>
+            <h1 className="mt-8 text-5xl font-semibold leading-[0.95] tracking-[-0.055em] text-foreground sm:text-7xl lg:text-[5.6rem]">
+              React Foundation
+              <span className="block bg-gradient-to-r from-primary via-primary to-success bg-clip-text text-transparent">
+                Summit
+              </span>
+            </h1>
+            <p className="mt-8 max-w-xl text-lg leading-8 text-muted-foreground sm:text-xl">
+              Three days in London to turn a distributed Foundation into a connected community—with shared direction, stronger relationships, and momentum for what comes next.
+            </p>
+
+            <div className="mt-9 flex flex-wrap gap-3">
+              <RFDS.ButtonLink href="#programme" size="lg">
+                Explore the programme
+                <ArrowDown className="h-4 w-4" aria-hidden="true" />
+              </RFDS.ButtonLink>
+              <RFDS.ButtonLink href="/summit-2026.ics" variant="tertiary" size="lg" download>
+                <Download className="h-4 w-4" aria-hidden="true" />
+                Add to calendar
+              </RFDS.ButtonLink>
+            </div>
+
+            <dl className="mt-12 grid max-w-2xl gap-6 border-t border-border/70 pt-7 sm:grid-cols-3">
+              <div>
+                <dt className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <CalendarDays className="h-4 w-4 text-primary" aria-hidden="true" /> Dates
+                </dt>
+                <dd className="mt-2 font-semibold text-foreground">10–12 Nov 2026</dd>
+              </div>
+              <div>
+                <dt className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <MapPin className="h-4 w-4 text-primary" aria-hidden="true" /> Location
+                </dt>
+                <dd className="mt-2 font-semibold text-foreground">London, UK</dd>
+              </div>
+              <div>
+                <dt className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <UsersRound className="h-4 w-4 text-primary" aria-hidden="true" /> Gathering
+                </dt>
+                <dd className="mt-2 font-semibold text-foreground">75–100 members</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className={`${styles.orbital} relative mx-auto hidden aspect-square w-full max-w-[34rem] lg:block`} aria-hidden="true">
+            <div className={styles.orbitOne} />
+            <div className={styles.orbitTwo} />
+            <div className={styles.orbitThree} />
+            <div className="absolute inset-1/2 flex h-36 w-36 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-primary/25 bg-card/75 shadow-[0_0_80px_hsl(var(--primary)/0.25)] backdrop-blur-xl">
+              <Image
+                src="/react-logo.svg"
+                alt=""
+                width={96}
+                height={96}
+                className={styles.reactMark}
+              />
+            </div>
+            <span className="absolute left-[10%] top-[22%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">align</span>
+            <span className="absolute bottom-[18%] right-[6%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">build</span>
+            <span className="absolute bottom-[12%] left-[12%] rounded-full border border-border bg-card/80 px-3 py-1.5 font-mono text-xs text-muted-foreground shadow-lg backdrop-blur">connect</span>
+          </div>
+        </div>
+      </section>
+
+      <nav aria-label="Summit sections" className="sticky top-[4.5rem] z-40 border-y border-border/70 bg-background/85 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center gap-1 overflow-x-auto px-4 py-2 sm:justify-center sm:px-8">
+          {navigation.map((item) => (
+            <a key={item.href} href={item.href} className="shrink-0 rounded-full px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground">
+              {item.label}
+            </a>
+          ))}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/app/summit/summit-hero.tsx
+++ b/src/app/summit/summit-hero.tsx
@@ -24,10 +24,7 @@ export function SummitHero() {
       <section className="relative flex min-h-[calc(100svh-5rem)] items-center pt-28">
         <div className="mx-auto grid w-full max-w-7xl gap-14 px-6 py-16 sm:px-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:px-12 lg:py-24">
           <div>
-            <RFDS.Pill tone="sky" className="border-primary/30 bg-primary/5 text-foreground">
-              November 2026 · London
-            </RFDS.Pill>
-            <h1 className="mt-8 text-5xl font-semibold leading-[0.95] tracking-[-0.055em] text-foreground sm:text-7xl lg:text-[5.6rem]">
+            <h1 className="text-5xl font-semibold leading-[0.95] tracking-[-0.055em] text-foreground sm:text-7xl lg:text-[5.6rem]">
               Contributors
               <span className="block text-primary">
                 Summit 2026

--- a/src/app/summit/summit.module.css
+++ b/src/app/summit/summit.module.css
@@ -1,0 +1,140 @@
+.microsite {
+  isolation: isolate;
+}
+
+.gridBackdrop {
+  background-image:
+    linear-gradient(hsl(var(--border) / 0.28) 1px, transparent 1px),
+    linear-gradient(90deg, hsl(var(--border) / 0.28) 1px, transparent 1px);
+  background-size: 52px 52px;
+  mask-image: linear-gradient(to bottom, hsl(var(--foreground)) 20%, transparent 92%);
+}
+
+.heroGlow {
+  animation: glow-drift 14s ease-in-out infinite alternate;
+  background:
+    radial-gradient(circle at 30% 50%, hsl(var(--primary) / 0.32), transparent 42%),
+    radial-gradient(circle at 72% 42%, hsl(var(--success) / 0.22), transparent 38%);
+  filter: blur(48px);
+}
+
+.orbital {
+  animation: float 7s ease-in-out infinite;
+}
+
+.orbitOne,
+.orbitTwo,
+.orbitThree {
+  border: 1px solid hsl(var(--primary) / 0.2);
+  border-radius: 9999px;
+  inset: 50%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+.orbitOne {
+  animation: orbit-spin 22s linear infinite;
+  height: 13rem;
+  width: 13rem;
+}
+
+.orbitTwo {
+  animation: orbit-spin-reverse 28s linear infinite;
+  border-color: hsl(var(--success) / 0.2);
+  height: 18rem;
+  width: 18rem;
+}
+
+.orbitThree {
+  animation: orbit-spin 34s linear infinite;
+  height: 23rem;
+  width: 23rem;
+}
+
+.orbitOne::after,
+.orbitTwo::after,
+.orbitThree::after {
+  background: hsl(var(--primary));
+  border-radius: 9999px;
+  box-shadow: 0 0 24px hsl(var(--primary) / 0.75);
+  content: "";
+  height: 0.55rem;
+  left: 50%;
+  position: absolute;
+  top: -0.3rem;
+  width: 0.55rem;
+}
+
+.orbitTwo::after {
+  background: hsl(var(--success));
+  box-shadow: 0 0 24px hsl(var(--success) / 0.75);
+}
+
+.orbitThree::after {
+  height: 0.35rem;
+  width: 0.35rem;
+}
+
+.reactMark {
+  filter: drop-shadow(0 0 22px hsl(var(--primary) / 0.6));
+}
+
+.dateNumber {
+  background: linear-gradient(135deg, hsl(var(--foreground)), hsl(var(--primary)));
+  background-clip: text;
+  color: transparent;
+}
+
+.agendaLine {
+  background: linear-gradient(to bottom, hsl(var(--primary)), hsl(var(--success) / 0.35));
+}
+
+.faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq[open] .faqIcon {
+  transform: rotate(45deg);
+}
+
+@keyframes glow-drift {
+  from {
+    opacity: 0.7;
+    transform: translate3d(-3%, -2%, 0) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(4%, 3%, 0) scale(1.08);
+  }
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-12px);
+  }
+}
+
+@keyframes orbit-spin {
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+@keyframes orbit-spin-reverse {
+  to {
+    transform: translate(-50%, -50%) rotate(-360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heroGlow,
+  .orbital,
+  .orbitOne,
+  .orbitTwo,
+  .orbitThree {
+    animation: none;
+  }
+}

--- a/src/app/summit/summit.module.css
+++ b/src/app/summit/summit.module.css
@@ -2,22 +2,6 @@
   isolation: isolate;
 }
 
-.gridBackdrop {
-  background-image:
-    linear-gradient(hsl(var(--border) / 0.28) 1px, transparent 1px),
-    linear-gradient(90deg, hsl(var(--border) / 0.28) 1px, transparent 1px);
-  background-size: 52px 52px;
-  mask-image: linear-gradient(to bottom, hsl(var(--foreground)) 20%, transparent 92%);
-}
-
-.heroGlow {
-  animation: glow-drift 14s ease-in-out infinite alternate;
-  background:
-    radial-gradient(circle at 30% 50%, hsl(var(--primary) / 0.32), transparent 42%),
-    radial-gradient(circle at 72% 42%, hsl(var(--success) / 0.22), transparent 38%);
-  filter: blur(48px);
-}
-
 .orbital {
   animation: float 7s ease-in-out infinite;
 }
@@ -56,7 +40,6 @@
 .orbitThree::after {
   background: hsl(var(--primary));
   border-radius: 9999px;
-  box-shadow: 0 0 24px hsl(var(--primary) / 0.75);
   content: "";
   height: 0.55rem;
   left: 50%;
@@ -67,45 +50,11 @@
 
 .orbitTwo::after {
   background: hsl(var(--success));
-  box-shadow: 0 0 24px hsl(var(--success) / 0.75);
 }
 
 .orbitThree::after {
   height: 0.35rem;
   width: 0.35rem;
-}
-
-.reactMark {
-  filter: drop-shadow(0 0 22px hsl(var(--primary) / 0.6));
-}
-
-.dateNumber {
-  background: linear-gradient(135deg, hsl(var(--foreground)), hsl(var(--primary)));
-  background-clip: text;
-  color: transparent;
-}
-
-.agendaLine {
-  background: linear-gradient(to bottom, hsl(var(--primary)), hsl(var(--success) / 0.35));
-}
-
-.faq summary::-webkit-details-marker {
-  display: none;
-}
-
-.faq[open] .faqIcon {
-  transform: rotate(45deg);
-}
-
-@keyframes glow-drift {
-  from {
-    opacity: 0.7;
-    transform: translate3d(-3%, -2%, 0) scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(4%, 3%, 0) scale(1.08);
-  }
 }
 
 @keyframes float {
@@ -130,11 +79,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .heroGlow,
   .orbital,
   .orbitOne,
   .orbitTwo,
   .orbitThree {
     animation: none;
   }
+
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -98,6 +98,9 @@ export function Header() {
                 <Link className="transition hover:text-foreground" href="/communities">
                   Communities
                 </Link>
+                <Link className="transition hover:text-foreground" href="/summit">
+                  Summit
+                </Link>
                 {isAdmin && (
                   <Link
                     className="transition hover:text-foreground text-destructive font-medium"

--- a/src/components/layout/mobile-menu.tsx
+++ b/src/components/layout/mobile-menu.tsx
@@ -58,6 +58,7 @@ export function MobileMenu({ session }: MobileMenuProps) {
         { href: "/about", label: "About" },
         { href: "/impact", label: "Impact" },
         { href: "/communities", label: "Communities" },
+        { href: "/summit", label: "Summit" },
       ];
 
   return (

--- a/todos/nc-summit-todo.md
+++ b/todos/nc-summit-todo.md
@@ -1,0 +1,20 @@
+# nc/summit
+
+## Completed
+
+- [x] Add the React Foundation Contributors Summit 2026 participant page at `/summit`.
+- [x] Present the purpose, programme, joining information, and logistics using RFDS components and semantic theme tokens.
+- [x] Add an animated participant FAQ and multi-provider calendar menu.
+- [x] Add an interactive OpenStreetMap/CARTO map for central London.
+- [x] Link the summit from desktop and mobile navigation.
+- [x] Add the summit route to the generated sitemap.
+- [x] Verify the page-specific TypeScript and ESLint results.
+
+## Deferred
+
+- [ ] Replace the temporary self-nomination form URL when the final form is provided.
+- [ ] Add the final venue, travel, accommodation, catering, and exact session details when summit logistics are confirmed.
+
+## Next Steps
+
+- Replace the provisional logistics copy, central London map marker, and last-updated date as details are finalized.


### PR DESCRIPTION
Removes the small uppercase 'eyebrow' labels used throughout the Summit microsite:

- Hero pill ("November 2026 · London") above the H1
- The `eyebrow` prop/paragraph rendered above every `SectionHeading` (Why, Programme, Joining, Plan, FAQ sections)
- The "Self-nominations" label above the self-nomination card heading
- The closing CTA badge ("10–12 November · London") above the final heading

The `SectionHeading` component's `eyebrow` prop was removed entirely along with all call sites that passed it.