### PR TITLE
Update Summit logistics copy

### DIFF
--- a/src/app/summit/page.tsx
+++ b/src/app/summit/page.tsx
@@ -132,8 +132,8 @@ export default function SummitPage() {
           <div className="grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-start lg:gap-20">
             <RFDS.ScrollReveal animation="slide-right">
               <SectionHeading
-                eyebrow="Joining the summit"
-                title="An invite-only working summit."
+                eyebrow="Joining the Summit"
+                title="An invite-only working Summit."
                 description="Attendance is invite only for members of the React Foundation working groups."
               />
               <RFDS.SemanticBadge variant="outline" className="mt-7 border-primary/30">
@@ -171,9 +171,9 @@ export default function SummitPage() {
         <div className="mx-auto max-w-7xl px-6 sm:px-8 lg:px-12">
           <RFDS.ScrollReveal animation="fade-up">
             <SectionHeading
-              eyebrow="Plan your summit"
+              eyebrow="Plan your Summit"
               title="Logistics"
-              description="London and the dates are set. Venue, travel, accommodation, and catering details are still being coordinated and will be published here as they are confirmed."
+              description="London and the dates are set. Venue details will be published here once confirmed."
             />
           </RFDS.ScrollReveal>
 
@@ -200,7 +200,7 @@ export default function SummitPage() {
               <Clock3 className="h-6 w-6 text-primary" aria-hidden="true" />
               <h3 className="mt-6 text-xl font-semibold text-foreground">Before you book</h3>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                Plan to arrive on Monday 9 November and depart on Friday 13 November. Wait for the logistics update before booking non-refundable travel or accommodation.
+                Plan to arrive on Monday 9 November and depart on Friday 13 November. More information about the venue will be shared once it has been confirmed.
               </p>
               <SummitCalendarMenu variant="secondary" size="sm" className="mt-6" />
             </RFDS.SemanticCard>
@@ -216,7 +216,7 @@ export default function SummitPage() {
               <SectionHeading
                 eyebrow="Participant FAQ"
                 title="The details, in one place."
-                description="This is the source of truth for summit participants. Confirmed information is stated plainly; open logistics are marked as such."
+                description="This is the source of truth for Summit participants. Confirmed information is stated plainly; open logistics are marked as such."
               />
               <p className="mt-6 text-xs text-muted-foreground">Last updated 22 July 2026</p>
             </RFDS.ScrollReveal>

--- a/src/app/summit/summit-data.ts
+++ b/src/app/summit/summit-data.ts
@@ -61,7 +61,7 @@ export const summitDays: readonly SummitDay[] = [
     date: "November",
     label: "Travel day",
     audience: "Arrivals",
-    focus: "Travel to London and settle in ahead of the summit.",
+    focus: "Travel to London and settle in ahead of the Summit.",
     isTravel: true,
   },
   {
@@ -94,15 +94,15 @@ export const summitDays: readonly SummitDay[] = [
     date: "November",
     label: "Travel day",
     audience: "Departures",
-    focus: "Depart London after three days of summit sessions.",
+    focus: "Depart London after three days of Summit sessions.",
     isTravel: true,
   },
 ];
 
 export const faqItems: readonly FaqItem[] = [
   {
-    question: "When and where is the summit?",
-    answer: "The summit sessions take place in London from Tuesday 10 to Thursday 12 November 2026. Monday 9 and Friday 13 November are travel days. The exact London venue is still to be confirmed.",
+    question: "When and where is the Summit?",
+    answer: "The Summit sessions take place in London from Tuesday 10 to Thursday 12 November 2026. Monday 9 and Friday 13 November are travel days. The exact London venue is still to be confirmed.",
   },
   {
     question: "Who is invited?",
@@ -110,7 +110,7 @@ export const faqItems: readonly FaqItem[] = [
   },
   {
     question: "Is this a public conference?",
-    answer: "No. The current format is a working summit, not a public conference. Non-members of the React Foundation can",
+    answer: "No. The current format is a working Summit, not a public conference. Non-members of the React Foundation can",
     link: {
       href: "#joining",
       label: "self-nominate using the form.",
@@ -130,7 +130,7 @@ export const faqItems: readonly FaqItem[] = [
   },
   {
     question: "Are travel and accommodation arranged?",
-    answer: "Travel coordination, accommodation guidance, and reimbursement details will be shared with participants. If you have special travel needs, please include them in the registration form sent to participants by email.",
+    answer: "The React Foundation will not be able to sponsor travel for every participant. Where possible, we hope participants’ employers will cover their travel and accommodation costs as a way of supporting the Foundation. If you need additional support to attend, however, please reach out to the Foundation directly.",
   },
   {
     question: "Will meals be provided?",


### PR DESCRIPTION
## Summary

- capitalize “Summit” consistently across the Summit page
- simplify the venue logistics copy and future-update notice
- clarify that the Foundation cannot sponsor every participant’s travel, encourage employer support, and invite participants needing additional support to reach out

## Testing

- `git diff --check`
- TypeScript and lint could not run because dependencies are not installed and the npm registry returned HTTP 503 during installation