### PR TITLE
Resolve header auth state server-side

### DIFF
--- a/scripts/static-routes.test.mjs
+++ b/scripts/static-routes.test.mjs
@@ -5,11 +5,15 @@ import test from 'node:test';
 const manifestPath = new URL('../.next/prerender-manifest.json', import.meta.url);
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
 
-test('public content routes are prerendered', () => {
+test('routes with a personalized header are server-rendered', () => {
   const publicRoutes = ['/', '/about', '/communities', '/libraries', '/updates'];
 
   for (const route of publicRoutes) {
-    assert.ok(manifest.routes[route], `${route} should be present in the prerender manifest`);
+    assert.equal(
+      manifest.routes[route],
+      undefined,
+      `${route} should resolve the header session at request time`,
+    );
   }
 });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Header } from "@/components/layout/header";
+import { getServerAuthSession } from "@/lib/auth";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -80,11 +81,13 @@ export const metadata: Metadata = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await getServerAuthSession();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -122,7 +125,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider defaultTheme="system">
-          <AuthProvider>
+          <AuthProvider session={session}>
             <Header />
             {children}
           </AuthProvider>


### PR DESCRIPTION
## Summary

- Resolve the NextAuth session in the root layout before rendering the header.
- Seed `SessionProvider` with that server session so the first render shows either the sign-in button or the authenticated avatar.
- Update the rendering-contract test to require request rendering for routes with the personalized header.

## Why

The root auth provider previously started without a session. The header rendered no authentication control while `useSession()` was loading, then inserted either the sign-in button or avatar after a client-side session request. That late insertion caused the navigation layout shift.

Resolving the session on the server removes the indeterminate first render and sends the correct authentication control in the initial HTML. Under the current Next.js configuration, this intentionally changes header-bearing public routes from fully prerendered output to request-rendered output.

## Validation

- `npm run build`
- `npx vitest run src/components/layout/header.test.tsx`
- `npx eslint src/app/layout.tsx src/components/providers/auth-provider.tsx src/components/layout/header.tsx scripts/static-routes.test.mjs`
- `npx tsc --noEmit`
- Confirmed an unauthenticated request contains `Sign in` in the initial server HTML.
