### PR TITLE
Update Summit last updated date

### DIFF
--- a/src/app/summit/page.tsx
+++ b/src/app/summit/page.tsx
@@ -218,7 +218,7 @@ export default function SummitPage() {
                 title="The details, in one place."
                 description="This is the source of truth for Summit participants. Confirmed information is stated plainly; open logistics are marked as such."
               />
-              <p className="mt-6 text-xs text-muted-foreground">Last updated 22 July 2026</p>
+              <p className="mt-6 text-xs text-muted-foreground">Last updated 13 August 2026</p>
             </RFDS.ScrollReveal>
           </div>
 

--- a/src/app/summit/summit-data.ts
+++ b/src/app/summit/summit-data.ts
@@ -143,6 +143,6 @@ export const faqItems: readonly FaqItem[] = [
   {
     question: "Where will updates be published?",
     answer: "This page is the participant source of truth and will be updated as venue, logistics, travel, and detailed scheduling decisions are finalized.",
-    updatedAt: "22 July 2026",
+    updatedAt: "13 August 2026",
   },
 ];


### PR DESCRIPTION
## Summary

Updates both Summit page references from 22 July 2026 to 13 August 2026.

---

## Linked Issue or Exception

No linked issue is needed for this small content correction.

---

## Root Cause (for bugs)

The visible FAQ timestamp and its associated update note still showed the previous July date.

---

## Solution

Updated both references so the Summit participant source of truth consistently shows 13 August 2026.

---

## Scope

- [x] This PR has a single concern
- [x] Refactors are directly required for this change
- [x] No unrelated formatting or cleanup is included

---

## Test Plan

- [x] Verified TypeScript passes with `npx tsc --noEmit`
- [x] Verified focused ESLint passes for both changed files
- [x] Confirmed no old Summit date reference remains

Repository-wide `npm run lint` currently reports 155 pre-existing issues in unrelated files.

---

## Screenshots (if UI)

Not included; this is a two-reference date-only content update.

---

## Checklist

- [x] Code follows existing patterns
- [x] No unnecessary abstractions
- [x] No console logs or debug code
- [x] No unresolved TODOs introduced
- [ ] CI passing

---

## Notes for Reviewers

Both the FAQ section label and the FAQ item update note now use the same date.