### PR TITLE
Fix: schedule the ingestion route that stores the content map

### DIFF
--- a/.github/workflows/trigger-ingestion.yml
+++ b/.github/workflows/trigger-ingestion.yml
@@ -12,15 +12,6 @@ on:
         options:
           - production
           - preview
-      max_pages:
-        description: 'Maximum pages to crawl (0 = unlimited)'
-        required: false
-        default: '100'
-      use_sitemap:
-        description: 'Use sitemap.xml for discovery'
-        required: false
-        default: 'true'
-        type: boolean
 
   # Option 2: Scheduled (daily at 2 AM UTC)
   schedule:
@@ -37,28 +28,22 @@ jobs:
       - name: Trigger ingestion API
         run: |
           ENVIRONMENT="${{ github.event.inputs.environment || 'production' }}"
-          MAX_PAGES="${{ github.event.inputs.max_pages || '100' }}"
-          USE_SITEMAP="${{ github.event.inputs.use_sitemap || 'true' }}"
 
           if [ "$ENVIRONMENT" = "production" ]; then
-            URL="https://react.foundation/api/admin/ingest"
+            BASE_URL="https://react.foundation"
           else
-            URL="https://preview.react.foundation/api/admin/ingest"
+            BASE_URL="https://preview.react.foundation"
           fi
+
+          # /api/ingest/full is the only route that runs the loaders and stores
+          # the content map. It reads no request body.
+          URL="$BASE_URL/api/ingest/full"
 
           echo "🚀 Triggering ingestion for $ENVIRONMENT..."
           echo "   URL: $URL"
-          echo "   Max pages: $MAX_PAGES"
-          echo "   Use sitemap: $USE_SITEMAP"
 
           RESPONSE=$(curl -X POST "$URL" \
             -H "Authorization: Bearer ${{ secrets.INGESTION_API_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"maxPages\": $MAX_PAGES,
-              \"useSitemap\": $USE_SITEMAP,
-              \"clearExisting\": false
-            }" \
             -w "\n%{http_code}" \
             -s)
 
@@ -68,18 +53,41 @@ jobs:
           echo "Response:"
           echo "$BODY" | jq '.'
 
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Ingestion started successfully"
-            INGESTION_ID=$(echo "$BODY" | jq -r '.ingestionId')
-            echo "   Ingestion ID: $INGESTION_ID"
-          else
+          if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ Failed with HTTP $HTTP_CODE"
             exit 1
           fi
 
-      - name: Wait for completion (optional)
-        if: github.event_name == 'workflow_dispatch'
+          INGESTION_ID=$(echo "$BODY" | jq -r '.ingestionId')
+          echo "✅ Ingestion started: $INGESTION_ID"
+
+          echo "BASE_URL=$BASE_URL" >> "$GITHUB_ENV"
+          echo "INGESTION_ID=$INGESTION_ID" >> "$GITHUB_ENV"
+
+      - name: Wait for the ingestion to finish
         run: |
-          echo "⏳ Waiting for ingestion to complete..."
-          echo "   Check status at: https://react.foundation/admin/data"
-          sleep 10
+          # The POST above only starts the run. Without this check the job stays
+          # green even when no new content map is stored.
+          STATUS_URL="$BASE_URL/api/ingest/full?ingestionId=$INGESTION_ID"
+          DEADLINE=$((SECONDS + 900))
+
+          while [ "$SECONDS" -lt "$DEADLINE" ]; do
+            STATUS=$(curl -s "$STATUS_URL" | jq -r '.status // "unknown"')
+            echo "   status: $STATUS"
+
+            if [ "$STATUS" = "completed" ]; then
+              echo "✅ Ingestion completed"
+              exit 0
+            fi
+
+            if [ "$STATUS" = "failed" ]; then
+              echo "❌ Ingestion failed"
+              curl -s "$STATUS_URL" | jq -r '.error // empty, .logs[-10:][]?'
+              exit 1
+            fi
+
+            sleep 15
+          done
+
+          echo "❌ Ingestion did not reach completion within 15 minutes"
+          exit 1

--- a/src/lib/ingest/content-map-schedule.test.ts
+++ b/src/lib/ingest/content-map-schedule.test.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readdirSync, readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(dirname, '..', '..', '..');
+const appRoot = path.join(repoRoot, 'src', 'app');
+const scheduledWorkflow = readFileSync(
+  path.join(repoRoot, '.github', 'workflows', 'trigger-ingestion.yml'),
+  'utf8'
+);
+
+function collectRouteFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectRouteFiles(entryPath);
+    return entry.name === 'route.ts' ? [entryPath] : [];
+  });
+}
+
+function toRoutePath(routeFile: string): string {
+  const segments = path.relative(appRoot, path.dirname(routeFile)).split(path.sep);
+  return `/${segments.join('/')}`;
+}
+
+const contentMapRoutes = collectRouteFiles(path.join(appRoot, 'api'))
+  .filter((file) => readFileSync(file, 'utf8').includes('storeContentMap('))
+  .map(toRoutePath);
+
+describe('scheduled content map refresh', () => {
+  it('keeps a single route as the place that stores the content map', () => {
+    expect(contentMapRoutes).toEqual(['/api/ingest/full']);
+  });
+
+  it('schedules ingestion against the route that stores the content map', () => {
+    expect(scheduledWorkflow).toContain(contentMapRoutes[0]);
+  });
+
+  it('fails the run when the ingestion does not reach completion', () => {
+    expect(scheduledWorkflow).toContain('ingestionId=');
+    expect(scheduledWorkflow).toContain('"completed"');
+  });
+});


### PR DESCRIPTION
Closes #120

### What this changes

The nightly workflow now posts to `/api/ingest/full` and waits for the run to reach `completed`.

### Why

`/api/content-map` reads a snapshot from Redis with `loadContentMap`. It does not build the map. Only `src/app/api/ingest/full/route.ts` builds and stores it, with `generateContentMap` and `storeContentMap` on lines 201-202. It is also the only route that uses `LibrariesLoader` (line 138).

Both ingestion workflows posted to `/api/admin/ingest`. That route runs `IngestionService` from `src/lib/chatbot/ingest.ts`, which has no reference to `generateContentMap`, `storeContentMap`, `LibrariesLoader` or `ecosystemLibraries`. It cannot update the content map.

The result is visible in production. `/api/ingest/full/latest` returns `ingest-full-1763746677379`, which is 2025-11-21. `/api/content-map` still serves 13 `/docs` URLs that return 404, and it still misses the four libraries added in #104. Both were fixed on `main` on 2026-08-11.

The failure stayed silent because the workflow treated the HTTP 200 of "Ingestion started" as success. It was green every night while nothing was written.

### Questions a reviewer may ask

**Why remove the `max_pages` and `use_sitemap` inputs?** `/api/ingest/full` never reads `request.json()`. It takes no body. Inputs that are sent and ignored would describe behaviour that does not exist.

**Does the nightly run now ingest less?** No. In production the old target skipped crawling on purpose. `src/lib/chatbot/ingest.ts:106` says "Skipping website crawl in production (self-crawling causes deadlocks)" and falls back to `public-context/`. `/api/ingest/full` loads the same `public-context/` files through `MDXLoader`, and adds `PagesLoader`, `CommunitiesLoader` and `LibrariesLoader`, then stores the content map.

**Does the status check need a secret?** No. `GET /api/ingest/full?ingestionId=<id>` has no auth check. Checked against production: an unknown id returns `{"error":"Ingestion not found"}`.

**Will this alone make the content map fresh?** Not guaranteed. `upsertRecords` runs on line 180, before `generateContentMap` on line 201. If embedding generation fails, the map is never stored, and `/api/ingest/full/stats` reports `num_docs: 0` today. This PR does not fix that. It makes such a run fail instead of pass.

### Test

`src/lib/ingest/content-map-schedule.test.ts` scans `src/app/api` for the route that calls `storeContentMap`, derives its URL path, and asserts that the scheduled workflow targets that path and waits for completion. It uses an invariant instead of a hard-coded URL, so the test keeps working if the route moves.

On `main` the test fails:

```
× schedules ingestion against the route that stores the content map
× fails the run when the ingestion does not reach completion
Tests  2 failed | 1 passed (3)
```

With this change:

```
✓ src/lib/ingest/content-map-schedule.test.ts (3 tests)
Test Files  1 passed (1)
```

### Local checks

```
vitest (unit project)   46 passed, 15 files
tsc --noEmit            0 errors
eslint                  0 problems
bash -n                 both run blocks parse
```

The `storybook` vitest project does not start on Windows, so the `unit` project was run through an equivalent local config. That file is not part of this branch.

### Non-goals

- The empty `rf:chunks-idx` index and the embedding path.
- `.github/workflows/ingest-content.yml`. It waits for a `workflow_run` from a workflow named "Vercel Production Deployment" that does not exist in this repo, and it has 0 runs in total.
- Any change to `generateContentMap`, `storeContentMap` or the loaders.
